### PR TITLE
fix: 🐛 Made stashing only work on right click again, left click will …

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.daemon=false
 minecraft_version=1.19.2
 forge_version=43.2.7
-mod_version=0.6.26
+mod_version=0.6.27
 jei_mc_version=1.19.1-forge
 jei_version=11.2.0.244
 quark_cf_file_id=4463411

--- a/src/main/java/net/p3pp3rf1y/sophisticatedstorage/item/ShulkerBoxItem.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedstorage/item/ShulkerBoxItem.java
@@ -178,7 +178,7 @@ public class ShulkerBoxItem extends StorageBlockItem implements IStashStorageIte
 
 	@Override
 	public boolean overrideStackedOnOther(ItemStack storageStack, Slot slot, ClickAction action, Player player) {
-		if (!slot.mayPickup(player)) {
+		if (!slot.mayPickup(player) || action != ClickAction.SECONDARY) {
 			return super.overrideStackedOnOther(storageStack, slot, action, player);
 		}
 
@@ -195,7 +195,7 @@ public class ShulkerBoxItem extends StorageBlockItem implements IStashStorageIte
 
 	@Override
 	public boolean overrideOtherStackedOnMe(ItemStack storageStack, ItemStack otherStack, Slot slot, ClickAction action, Player player, SlotAccess carriedAccess) {
-		if (!slot.mayPlace(storageStack)) {
+		if (!slot.mayPlace(storageStack) || action != ClickAction.SECONDARY) {
 			return super.overrideOtherStackedOnMe(storageStack, otherStack, slot, action, player, carriedAccess);
 		}
 


### PR DESCRIPTION
…only switch the two stacks as it used to