### PR TITLE
fix: 🐛 Fix void upgrade overflow to work with hopper input even after…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.daemon=false
 minecraft_version=1.19.2
 forge_version=43.2.7
-mod_version=0.8.24
+mod_version=0.8.25
 jei_mc_version=1.19.1-forge
 jei_version=11.2.0.244
 quark_cf_file_id=4463411

--- a/src/main/java/net/p3pp3rf1y/sophisticatedstorage/block/LimitedBarrelBlockEntity.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedstorage/block/LimitedBarrelBlockEntity.java
@@ -44,12 +44,12 @@ public class LimitedBarrelBlockEntity extends BarrelBlockEntity implements ICoun
 
 	public LimitedBarrelBlockEntity(BlockPos pos, BlockState state) {
 		super(pos, state, ModBlocks.LIMITED_BARREL_BLOCK_ENTITY_TYPE.get());
-		registerClientNotificationOnCountChange();
 		registerUpgradeDefaults();
+		registerClientNotificationOnCountChange();
 	}
 
 	private void registerUpgradeDefaults() {
-		getStorageWrapper().getUpgradeHandler().registerUpgradeDefaultsHandler(VoidUpgradeWrapper.class, VOID_UPGRADE_VOIDING_OVERFLOW_OF_EVERYTHING_BY_DEFAULT);
+		getStorageWrapper().registerUpgradeDefaultsHandler(VoidUpgradeWrapper.class, VOID_UPGRADE_VOIDING_OVERFLOW_OF_EVERYTHING_BY_DEFAULT);
 	}
 
 	private void registerClientNotificationOnCountChange() {

--- a/src/main/java/net/p3pp3rf1y/sophisticatedstorage/block/StorageWrapper.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedstorage/block/StorageWrapper.java
@@ -17,6 +17,7 @@ import net.p3pp3rf1y.sophisticatedcore.settings.SettingsHandler;
 import net.p3pp3rf1y.sophisticatedcore.settings.itemdisplay.ItemDisplaySettingsCategory;
 import net.p3pp3rf1y.sophisticatedcore.settings.memory.MemorySettingsCategory;
 import net.p3pp3rf1y.sophisticatedcore.settings.nosort.NoSortSettingsCategory;
+import net.p3pp3rf1y.sophisticatedcore.upgrades.IUpgradeWrapper;
 import net.p3pp3rf1y.sophisticatedcore.upgrades.UpgradeHandler;
 import net.p3pp3rf1y.sophisticatedcore.upgrades.stack.StackUpgradeItem;
 import net.p3pp3rf1y.sophisticatedcore.util.InventorySorter;
@@ -28,11 +29,13 @@ import net.p3pp3rf1y.sophisticatedstorage.settings.StorageSettingsHandler;
 
 import javax.annotation.Nullable;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 public abstract class StorageWrapper implements IStorageWrapper {
@@ -68,6 +71,8 @@ public abstract class StorageWrapper implements IStorageWrapper {
 	private int accentColor = -1;
 
 	private Runnable upgradeCachesInvalidatedHandler = () -> {};
+
+	private final Map<Class<? extends IUpgradeWrapper>, Consumer<? extends IUpgradeWrapper>> upgradeDefaultsHandlers = new HashMap<>();
 
 	protected StorageWrapper(Supplier<Runnable> getSaveHandler, Runnable onSerializeRenderInfo, Runnable markContentsDirty) {
 		this(getSaveHandler, onSerializeRenderInfo, markContentsDirty, 1);
@@ -130,8 +135,14 @@ public abstract class StorageWrapper implements IStorageWrapper {
 				}
 
 			};
+			upgradeDefaultsHandlers.forEach(this::registerUpgradeDefaultsHandlerInUpgradeHandler);
 		}
 		return upgradeHandler;
+	}
+
+	private <T extends IUpgradeWrapper> void registerUpgradeDefaultsHandlerInUpgradeHandler(Class<T> wrapperClass, Consumer<? extends IUpgradeWrapper> defaultsHandler) {
+		//noinspection DataFlowIssue, unchecked - only called after upgradeHandler is initialized
+		upgradeHandler.registerUpgradeDefaultsHandler(wrapperClass, (Consumer<T>) defaultsHandler);
 	}
 
 	@Override
@@ -430,5 +441,9 @@ public abstract class StorageWrapper implements IStorageWrapper {
 			numberOfUpgradeSlots += additionalUpgradeSlots;
 			getUpgradeHandler().increaseSize(additionalUpgradeSlots);
 		}
+	}
+
+	public <T extends IUpgradeWrapper> void registerUpgradeDefaultsHandler(Class<T> upgradeClass, Consumer<T> defaultsHandler) {
+		upgradeDefaultsHandlers.put(upgradeClass, defaultsHandler);
 	}
 }


### PR DESCRIPTION
… world reload or after additional upgrades are inserted