### PR TITLE
fix: 🐛 Fix storage tier upgrade recipes JEI integration to not crash …

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.daemon=false
 minecraft_version=1.19.2
 forge_version=43.2.13
-mod_version=0.8.38
+mod_version=0.8.39
 jei_mc_version=1.19.1-forge
 jei_version=11.2.0.244
 quark_cf_file_id=4463411

--- a/src/main/java/net/p3pp3rf1y/sophisticatedstorage/compat/jei/TierUpgradeRecipesMaker.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedstorage/compat/jei/TierUpgradeRecipesMaker.java
@@ -45,14 +45,12 @@ public class TierUpgradeRecipesMaker {
 				int i = 0;
 				for (Ingredient ingredient : ingredients) {
 					ItemStack[] ingredientItems = ingredient.getItems();
-					if (ingredientItems.length == 1) {
-						if (storageItem.getItem() == ingredientItems[0].getItem()) {
-							ingredientsCopy.add(i, Ingredient.of(storageItem));
-							craftinginventory.setItem(i, storageItem.copy());
-						} else {
-							ingredientsCopy.add(i, ingredient);
-							craftinginventory.setItem(i, ingredientItems[0]);
-						}
+					if (ingredientItems.length == 1 && storageItem.getItem() == ingredientItems[0].getItem()) {
+						ingredientsCopy.add(i, Ingredient.of(storageItem));
+						craftinginventory.setItem(i, storageItem.copy());
+					} else {
+						ingredientsCopy.add(i, ingredient);
+						craftinginventory.setItem(i, ingredientItems[0]);
 					}
 					i++;
 				}


### PR DESCRIPTION
…when additional alternatives to upgrade materials exist and by extension stop this from breaking the whole Storage JEI integration