### PR TITLE
fix: 🐛 Fix storage tier upgrade recipes JEI integration to not crash …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,6 @@ dependencies {
     compileOnly fg.deobf("curse.maven:rubidium-574856:${rubidium_cf_file_id}")
     compileOnly fg.deobf("curse.maven:jade-324717:${jade_cf_file_id}")
 
-    //runtimeOnly fg.deobf("curse.maven:rubidium-574856:${rubidium_cf_file_id}")
 /*
     compileOnly fg.deobf("curse.maven:quark-243121:${quark_cf_file_id}")
     compileOnly fg.deobf("curse.maven:autoreglib-250363:${autoreglib_cf_file_id}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 minecraft_version=1.20.1
 forge_version=47.0.16
-mod_version=0.8.43
+mod_version=0.8.44
 jei_mc_version=1.20.1-forge
 jei_version=15.1.0.19
 rubidium_cf_file_id=4573226

--- a/src/main/java/net/p3pp3rf1y/sophisticatedstorage/compat/jei/TierUpgradeRecipesMaker.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedstorage/compat/jei/TierUpgradeRecipesMaker.java
@@ -60,14 +60,12 @@ public class TierUpgradeRecipesMaker {
 				int i = 0;
 				for (Ingredient ingredient : ingredients) {
 					ItemStack[] ingredientItems = ingredient.getItems();
-					if (ingredientItems.length == 1) {
-						if (storageItem.getItem() == ingredientItems[0].getItem()) {
-							ingredientsCopy.add(i, Ingredient.of(storageItem));
-							craftinginventory.setItem(i, storageItem.copy());
-						} else {
-							ingredientsCopy.add(i, ingredient);
-							craftinginventory.setItem(i, ingredientItems[0]);
-						}
+					if (ingredientItems.length == 1 && storageItem.getItem() == ingredientItems[0].getItem()) {
+						ingredientsCopy.add(i, Ingredient.of(storageItem));
+						craftinginventory.setItem(i, storageItem.copy());
+					} else {
+						ingredientsCopy.add(i, ingredient);
+						craftinginventory.setItem(i, ingredientItems[0]);
 					}
 					i++;
 				}


### PR DESCRIPTION
…when additional alternatives to upgrade materials exist and by extension stop this from breaking the whole Storage JEI integration