### PR TITLE
1.19.x Alternate standalone implementation of Clearable for storage block inventories

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.daemon=false
 minecraft_version=1.19.2
 forge_version=43.2.13
-mod_version=0.8.56
+mod_version=0.8.57
 jei_mc_version=1.19.2-forge
 jei_version=11.6.0.1018
 quark_cf_file_id=4463411

--- a/src/main/java/net/p3pp3rf1y/sophisticatedstorage/block/StorageWrapper.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedstorage/block/StorageWrapper.java
@@ -197,6 +197,8 @@ public abstract class StorageWrapper implements IStorageWrapper {
 	public void load(CompoundTag tag) {
 		loadContents(tag);
 		loadData(tag);
+
+		getUpgradeHandler().refreshUpgradeWrappers();
 		if (Thread.currentThread().getThreadGroup() == SidedThreadGroups.SERVER && getRenderInfo().getUpgradeItems().size() != getUpgradeHandler().getSlots()) {
 			getUpgradeHandler().setRenderUpgradeItems();
 		}

--- a/src/main/java/net/p3pp3rf1y/sophisticatedstorage/block/WoodStorageBlockBase.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedstorage/block/WoodStorageBlockBase.java
@@ -165,6 +165,11 @@ public abstract class WoodStorageBlockBase extends StorageBlockBase implements I
 		}
 		b.setPacked(true);
 
+		BlockState blockState = b.getBlockState();
+		if (blockState.getBlock() instanceof StorageBlockBase storageBlock && blockState.getValue(StorageBlockBase.TICKING)) {
+			storageBlock.setTicking(player.level, b.getBlockPos(), blockState, false);
+		}
+
 		b.removeFromController();
 
 		WorldHelper.notifyBlockUpdate(b);


### PR DESCRIPTION
Adds support for Clearble to sophisticated storage block entities so
that other mods can explicitly clear the contents of an inventory before
destroying the inventory block entity.

Specifically, this will add compatibility with Valkyrien Skies 2 and
stop duplication of all items in sophisticated storage blocks when
assembling or disassembling ships with sophisticated blocks attached to
them.

Addresses https://github.com/P3pp3rF1y/SophisticatedStorage/issues/335

This change is standalone and requires no support code in
SophisticatedCore