### PR TITLE
fix: 🐛 Fix dropPacked config setting when on to also not show "too ma…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.daemon=false
 
 mod_id=sophisticatedstorage
 mod_group_id=sophisticatedstorage
-mod_version=0.10.19
+mod_version=0.10.20
 sonar_project_key=sophisticatedstorage:SophisticatedStorage
 github_package_url=https://maven.pkg.github.com/P3pp3rF1y/SophisticatedStorage
 

--- a/src/main/java/net/p3pp3rf1y/sophisticatedstorage/block/WoodStorageBlockBase.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedstorage/block/WoodStorageBlockBase.java
@@ -9,6 +9,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.ItemStack;
@@ -170,6 +171,27 @@ public abstract class WoodStorageBlockBase extends StorageBlockBase implements I
 		WoodStorageBlockItem.getWoodType(stack).ifPresent(be::setWoodType);
 		StorageBlockItem.getMainColorFromStack(stack).ifPresent(be.getStorageWrapper()::setMainColor);
 		StorageBlockItem.getAccentColorFromStack(stack).ifPresent(be.getStorageWrapper()::setAccentColor);
+	}
+
+	@Override
+	public void playerWillDestroy(Level level, BlockPos pos, BlockState state, Player player) {
+		super.playerWillDestroy(level, pos, state, player);
+		WorldHelper.getBlockEntity(level, pos, WoodStorageBlockEntity.class)
+				.ifPresent(wbe -> {
+					if (Boolean.TRUE.equals(Config.COMMON.dropPacked.get())) {
+						wbe.setPacked(true);
+
+						if (player.isCreative() && (
+								!InventoryHelper.isEmpty(wbe.getStorageWrapper().getInventoryHandler()) || !InventoryHelper.isEmpty(wbe.getStorageWrapper().getUpgradeHandler())
+						)) {
+							ItemStack drop = new ItemStack(this);
+							addDropData(drop, wbe);
+							ItemEntity itementity = new ItemEntity(level, pos.getX() + 0.5D, pos.getY() + 0.5D, pos.getZ() + 0.5D, drop);
+							itementity.setDefaultPickUpDelay();
+							level.addFreshEntity(itementity);
+						}
+					}
+				});
 	}
 
 	@SuppressWarnings("java:S1172") //parameter is used in override

--- a/src/main/java/net/p3pp3rf1y/sophisticatedstorage/block/WoodStorageBlockEntity.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedstorage/block/WoodStorageBlockEntity.java
@@ -13,7 +13,6 @@ import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.p3pp3rf1y.sophisticatedcore.util.NBTHelper;
-import net.p3pp3rf1y.sophisticatedstorage.Config;
 import net.p3pp3rf1y.sophisticatedstorage.item.WoodStorageBlockItem;
 
 import javax.annotation.Nonnull;
@@ -87,7 +86,7 @@ public abstract class WoodStorageBlockEntity extends StorageBlockEntity {
 
 	@Override
 	public boolean shouldDropContents() {
-		return !isPacked() && !Config.COMMON.dropPacked.get();
+		return !isPacked();
 	}
 
 	@Nonnull

--- a/src/main/java/net/p3pp3rf1y/sophisticatedstorage/common/CommonEventHandler.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedstorage/common/CommonEventHandler.java
@@ -101,7 +101,7 @@ public class CommonEventHandler {
 
 		Level level = player.level();
 		WorldHelper.getBlockEntity(level, event.getPos(), WoodStorageBlockEntity.class).ifPresent(wbe -> {
-			if (wbe.isPacked()) {
+			if (wbe.isPacked() || Boolean.TRUE.equals(Config.COMMON.dropPacked.get())) {
 				return;
 			}
 


### PR DESCRIPTION
…ny drops would happen if you break this block" message as all blocks are packed by default also made it so that if this config is on the packed storage drops for creative players as well when the storage has at least some item in it instead of deleting storage including its contents