### PR TITLE
fix: 🐛 Fixed double chest to show "too many drops" message when eithe…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.daemon=false
 
 mod_id=sophisticatedstorage
 mod_group_id=sophisticatedstorage
-mod_version=0.10.34
+mod_version=0.10.35
 sonar_project_key=sophisticatedstorage:SophisticatedStorage
 github_package_url=https://maven.pkg.github.com/P3pp3rF1y/SophisticatedStorage
 

--- a/src/main/java/net/p3pp3rf1y/sophisticatedstorage/common/CommonEventHandler.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedstorage/common/CommonEventHandler.java
@@ -21,6 +21,7 @@ import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.level.BlockEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.LogicalSide;
+import net.p3pp3rf1y.sophisticatedcore.inventory.InventoryHandler;
 import net.p3pp3rf1y.sophisticatedcore.network.PacketHandler;
 import net.p3pp3rf1y.sophisticatedcore.network.SyncPlayerSettingsMessage;
 import net.p3pp3rf1y.sophisticatedcore.settings.SettingsManager;
@@ -28,10 +29,7 @@ import net.p3pp3rf1y.sophisticatedcore.util.InventoryHelper;
 import net.p3pp3rf1y.sophisticatedcore.util.ItemBase;
 import net.p3pp3rf1y.sophisticatedcore.util.WorldHelper;
 import net.p3pp3rf1y.sophisticatedstorage.Config;
-import net.p3pp3rf1y.sophisticatedstorage.block.ISneakItemInteractionBlock;
-import net.p3pp3rf1y.sophisticatedstorage.block.LimitedBarrelBlock;
-import net.p3pp3rf1y.sophisticatedstorage.block.WoodStorageBlockBase;
-import net.p3pp3rf1y.sophisticatedstorage.block.WoodStorageBlockEntity;
+import net.p3pp3rf1y.sophisticatedstorage.block.*;
 import net.p3pp3rf1y.sophisticatedstorage.client.gui.StorageTranslationHelper;
 import net.p3pp3rf1y.sophisticatedstorage.init.ModItems;
 import net.p3pp3rf1y.sophisticatedstorage.settings.StorageSettingsHandler;
@@ -136,8 +134,19 @@ public class CommonEventHandler {
 			}
 
 			AtomicInteger droppedItemEntityCount = new AtomicInteger(0);
-			InventoryHelper.iterate(wbe.getStorageWrapper().getInventoryHandler(), (slot, stack) -> {
-				if (stack.isEmpty()) {
+
+			int startCountingFromSlot;
+			InventoryHandler inventoryHandler;
+			if (wbe instanceof ChestBlockEntity cbe && !cbe.isMainChest() && level.getBlockState(pos).getBlock() instanceof ChestBlock chestBlock) {
+				startCountingFromSlot = chestBlock.getNumberOfInventorySlots();
+				inventoryHandler = cbe.getMainStorageWrapper().getInventoryHandler();
+			} else {
+				startCountingFromSlot = 0;
+				inventoryHandler = wbe.getStorageWrapper().getInventoryHandler();
+			}
+
+			InventoryHelper.iterate(inventoryHandler, (slot, stack) -> {
+				if (stack.isEmpty() || slot < startCountingFromSlot) {
 					return;
 				}
 				droppedItemEntityCount.addAndGet((int) Math.ceil(stack.getCount() / (double) Math.min(stack.getMaxStackSize(), AVERAGE_MAX_ITEM_ENTITY_DROP_COUNT)));


### PR DESCRIPTION
…r of the parts of the chest gets broken by player and too many items would spill out of it