### PR TITLE
fix: 🐛 Fixed hopper upgrade occasionally freezing game due to it unne…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.daemon=false
 
 mod_id=sophisticatedstorage
 mod_group_id=sophisticatedstorage
-mod_version=0.10.35
+mod_version=0.10.36
 sonar_project_key=sophisticatedstorage:SophisticatedStorage
 github_package_url=https://maven.pkg.github.com/P3pp3rF1y/SophisticatedStorage
 

--- a/src/main/java/net/p3pp3rf1y/sophisticatedstorage/upgrades/hopper/HopperUpgradeWrapper.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedstorage/upgrades/hopper/HopperUpgradeWrapper.java
@@ -214,9 +214,25 @@ public class HopperUpgradeWrapper extends UpgradeWrapperBase<HopperUpgradeWrappe
 
 	@Override
 	public void onNeighborChange(Level level, BlockPos pos, Direction direction) {
-		if (pushDirections.contains(direction) || pullDirections.contains(direction)) {
+		if (!level.isClientSide() && (pushDirections.contains(direction) || pullDirections.contains(direction))
+				&& needsCacheUpdate(level, pos, direction)) {
 			updateCacheOnSide(level, pos, direction);
 		}
+	}
+
+	private boolean needsCacheUpdate(Level level, BlockPos pos, Direction direction) {
+		List<LazyOptional<IItemHandler>> handlers = handlerCache.get(direction);
+		if (handlers == null || handlers.isEmpty()) {
+			return !level.getBlockState(pos).isAir();
+		}
+
+		for (LazyOptional<IItemHandler> handler : handlers) {
+			if (!handler.isPresent()) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	public void updateCacheOnSide(Level level, BlockPos pos, Direction direction) {


### PR DESCRIPTION
…cessarily refreshing item handler cache for surrounding blocks and doing that on client side as well even though not needed there