### PR TITLE
fix: 🐛 Fixed scrollable inventory to only show slot background for sl…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.daemon=false
 
 mod_id=sophisticatedstorage
 mod_group_id=sophisticatedstorage
-mod_version=0.10.44
+mod_version=0.10.45
 sonar_project_key=sophisticatedstorage:SophisticatedStorage
 github_package_url=https://maven.pkg.github.com/P3pp3rF1y/SophisticatedStorage
 
@@ -30,6 +30,6 @@ jade_cf_file_id=4614153
 chipped_cf_file_id=5077656
 resourcefullib_cf_file_id=5070629
 athena_cf_file_id=4764357
-sc_version=[1.20.1-0.6.33,1.20.4)
+sc_version=[1.20.1-0.6.34,1.20.4)
 sb_version=[1.20.1-3.20.5,1.20.4)
 parchment_version=1.19.3-2023.03.12-1.20

--- a/src/main/java/net/p3pp3rf1y/sophisticatedstorage/client/gui/LimitedBarrelScreen.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedstorage/client/gui/LimitedBarrelScreen.java
@@ -30,7 +30,7 @@ public class LimitedBarrelScreen extends StorageScreen {
 	}
 
 	@Override
-	protected void drawSlotBg(GuiGraphics guiGraphics, int x, int y) {
+	protected void drawSlotBg(GuiGraphics guiGraphics, int x, int y, int visibleSlotsCount) {
 		LimitedBarrelScreen.drawSlotBg(this, guiGraphics, x, y, getMenu().getNumberOfStorageInventorySlots());
 	}
 

--- a/src/main/java/net/p3pp3rf1y/sophisticatedstorage/client/gui/LimitedBarrelSettingsScreen.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedstorage/client/gui/LimitedBarrelSettingsScreen.java
@@ -25,7 +25,7 @@ public class LimitedBarrelSettingsScreen extends StorageSettingsScreen {
 	}
 
 	@Override
-	protected void drawSlotBg(GuiGraphics guiGraphics, int x, int y) {
+	protected void drawSlotBg(GuiGraphics guiGraphics, int x, int y, int visibleSlotsCount) {
 		LimitedBarrelScreen.drawSlotBg(this, guiGraphics, x, y, getMenu().getNumberOfStorageInventorySlots());
 	}
 


### PR DESCRIPTION
…ots that exist. Fixes an issue with gold double chest by default showing background for slots that are not there making it seem like there's a bug with inventory interaction.