### PR TITLE
fix: 🐛 Fixed scrollable inventory to only show slot background for sl…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ loader_version_range=[4,)
 mod_id=sophisticatedstorage
 mod_name=Sophisticated Storage
 mod_license=GNU General Public License v3.0
-mod_version=0.10.44
+mod_version=0.10.45
 mod_group_id=sophisticatedstorage
 mod_authors=P3pp3rF1y, Ridanisaurus
 mod_description=Fancy and functional storage containers.
@@ -35,7 +35,7 @@ jade_cf_file_id=5109393
 chipped_cf_file_id=5506938
 resourcefullib_cf_file_id=5483169
 athena_cf_file_id=5431579
-sc_version=[1.21-0.6.42,1.22)
+sc_version=[1.21-0.6.44,1.22)
 sb_version=[1.21,1.22)
 
 #publish

--- a/src/main/java/net/p3pp3rf1y/sophisticatedstorage/client/gui/LimitedBarrelScreen.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedstorage/client/gui/LimitedBarrelScreen.java
@@ -30,7 +30,7 @@ public class LimitedBarrelScreen extends StorageScreen {
 	}
 
 	@Override
-	protected void drawSlotBg(GuiGraphics guiGraphics, int x, int y) {
+	protected void drawSlotBg(GuiGraphics guiGraphics, int x, int y, int visibleSlotsCount) {
 		LimitedBarrelScreen.drawSlotBg(this, guiGraphics, x, y, getMenu().getNumberOfStorageInventorySlots());
 	}
 

--- a/src/main/java/net/p3pp3rf1y/sophisticatedstorage/client/gui/LimitedBarrelSettingsScreen.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedstorage/client/gui/LimitedBarrelSettingsScreen.java
@@ -25,7 +25,7 @@ public class LimitedBarrelSettingsScreen extends StorageSettingsScreen {
 	}
 
 	@Override
-	protected void drawSlotBg(GuiGraphics guiGraphics, int x, int y) {
+	protected void drawSlotBg(GuiGraphics guiGraphics, int x, int y, int visibleSlotsCount) {
 		LimitedBarrelScreen.drawSlotBg(this, guiGraphics, x, y, getMenu().getNumberOfStorageInventorySlots());
 	}
 


### PR DESCRIPTION
…ots that exist. Fixes an issue with gold double chest by default showing background for slots that are not there making it seem like there's a bug with inventory interaction.