### PR TITLE
fix: 🐛 Fixed issue with compression upgrade's calculation of slot lim…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.daemon=false
 
 mod_id=sophisticatedstorage
 mod_group_id=sophisticatedstorage
-mod_version=0.10.49
+mod_version=0.10.50
 sonar_project_key=sophisticatedstorage:SophisticatedStorage
 github_package_url=https://maven.pkg.github.com/P3pp3rF1y/SophisticatedStorage
 

--- a/src/main/java/net/p3pp3rf1y/sophisticatedstorage/upgrades/compression/CompressionInventoryPart.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedstorage/upgrades/compression/CompressionInventoryPart.java
@@ -117,14 +117,10 @@ public class CompressionInventoryPart implements IInventoryPartHandler {
 	}
 
 	private void updateSlotLimits(Map<Integer, SlotDefinition> definitions) {
-		int lastMultiplier = 1;
 		int totalLimit = 0;
 		for (int slot = slotRange.firstSlot(); slot < slotRange.firstSlot() + slotRange.numberOfSlots(); slot++) {
 			if (definitions.containsKey(slot) && definitions.get(slot).isAccessible()) {
-				if (slot != slotRange.firstSlot()) {
-					lastMultiplier = intMaxCappedMultiply(lastMultiplier, definitions.get(slot).prevSlotMultiplier);
-				}
-				totalLimit = intMaxCappedAddition(totalLimit, intMaxCappedMultiply(lastMultiplier, parent.getBaseStackLimit(new ItemStack(definitions.get(slot).item))));
+				totalLimit = intMaxCappedAddition(parent.getBaseStackLimit(new ItemStack(definitions.get(slot).item)), intMaxCappedMultiply(definitions.get(slot).prevSlotMultiplier, totalLimit));
 
 				definitions.get(slot).setSlotLimit(totalLimit);
 			}

--- a/src/test/java/net/p3pp3rf1y/sophisticatedstorage/upgrades/compression/CompressionInventoryPartTest.java
+++ b/src/test/java/net/p3pp3rf1y/sophisticatedstorage/upgrades/compression/CompressionInventoryPartTest.java
@@ -55,6 +55,19 @@ public class CompressionInventoryPartTest {
 		recipeHelperMock.when(() -> RecipeHelper.getUncompactingResult(Items.IRON_BLOCK)).thenReturn(new RecipeHelper.UncompactingResult(Items.IRON_INGOT, RecipeHelper.CompactingShape.THREE_BY_THREE_UNCRAFTABLE));
 		recipeHelperMock.when(() -> RecipeHelper.getUncompactingResult(Items.IRON_INGOT)).thenReturn(new RecipeHelper.UncompactingResult(Items.IRON_NUGGET, RecipeHelper.CompactingShape.THREE_BY_THREE_UNCRAFTABLE));
 
+		recipeHelperMock.when(() -> RecipeHelper.getCompactingResult(Items.QUARTZ, RecipeHelper.CompactingShape.TWO_BY_TWO_UNCRAFTABLE)).thenReturn(AccessHelper.initCompactingResult(new ItemStack(Items.QUARTZ_BLOCK), Collections.emptyList()));
+		recipeHelperMock.when(() -> RecipeHelper.getCompactingResult(Items.QUARTZ_BLOCK, RecipeHelper.CompactingShape.THREE_BY_THREE_UNCRAFTABLE)).thenReturn(AccessHelper.initCompactingResult(new ItemStack(Items.STICK), Collections.emptyList()));
+		recipeHelperMock.when(() -> RecipeHelper.getCompactingResult(Items.STICK, RecipeHelper.CompactingShape.THREE_BY_THREE_UNCRAFTABLE)).thenReturn(AccessHelper.initCompactingResult(new ItemStack(Items.DEAD_BUSH), Collections.emptyList()));
+
+		recipeHelperMock.when(() -> RecipeHelper.getItemCompactingShapes(Items.QUARTZ)).thenReturn(Set.of(RecipeHelper.CompactingShape.TWO_BY_TWO_UNCRAFTABLE));
+		recipeHelperMock.when(() -> RecipeHelper.getItemCompactingShapes(Items.QUARTZ_BLOCK)).thenReturn(Set.of(RecipeHelper.CompactingShape.THREE_BY_THREE_UNCRAFTABLE));
+		recipeHelperMock.when(() -> RecipeHelper.getItemCompactingShapes(Items.STICK)).thenReturn(Set.of(RecipeHelper.CompactingShape.THREE_BY_THREE_UNCRAFTABLE));
+
+		recipeHelperMock.when(() -> RecipeHelper.getUncompactingResult(Items.DEAD_BUSH)).thenReturn(new RecipeHelper.UncompactingResult(Items.STICK, RecipeHelper.CompactingShape.THREE_BY_THREE_UNCRAFTABLE));
+		recipeHelperMock.when(() -> RecipeHelper.getUncompactingResult(Items.STICK)).thenReturn(new RecipeHelper.UncompactingResult(Items.QUARTZ_BLOCK, RecipeHelper.CompactingShape.THREE_BY_THREE_UNCRAFTABLE));
+		recipeHelperMock.when(() -> RecipeHelper.getUncompactingResult(Items.QUARTZ_BLOCK)).thenReturn(new RecipeHelper.UncompactingResult(Items.QUARTZ, RecipeHelper.CompactingShape.TWO_BY_TWO_UNCRAFTABLE));
+
+
 		ss = Mockito.mockStatic(SophisticatedStorage.class);
 		ss.when(() -> SophisticatedStorage.getRL(anyString())).thenAnswer(i -> new ResourceLocation(i.getArgument(0)));
 	}
@@ -415,12 +428,12 @@ public class CompressionInventoryPartTest {
 
 		assertStackEquals(params.insertResult, result, "Insert result doesn't match");
 		assertCalculatedStacks(params.calculatedStacksAfter, minSlot, part);
-		assertInternalStacks(params.internalStacksAfter, invHandler);
+		assertInternalStacks(params.changedInternalStacks, invHandler);
 	}
 
 	public record InsertItemUpdatesStacksParams(Map<Integer, ItemStack> internalStacksBefore, int baseSlotLimit,
 												int insertSlot, ItemStack stack, ItemStack insertResult,
-												Map<Integer, ItemStack> internalStacksAfter,
+												Map<Integer, ItemStack> changedInternalStacks,
 												Map<Integer, ItemStack> calculatedStacksAfter) {
 	}
 
@@ -514,6 +527,35 @@ public class CompressionInventoryPartTest {
 						new ItemStack(Items.IRON_INGOT, 7),
 						Map.of(0, new ItemStack(Items.IRON_INGOT, 64)),
 						Map.of(0, new ItemStack(Items.IRON_INGOT, 64), 1, new ItemStack(Items.IRON_NUGGET, 576))
+				),
+				new InsertItemUpdatesStacksParams(
+						Map.of(0, ItemStack.EMPTY, 1, new ItemStack(Items.STICK, 1), 2, new ItemStack(Items.QUARTZ_BLOCK, 1), 3, new ItemStack(Items.QUARTZ, 1)),
+						64,
+						0,
+						new ItemStack(Items.DEAD_BUSH, 1),
+						ItemStack.EMPTY,
+						Map.of(0, new ItemStack(Items.DEAD_BUSH, 1)),
+						Map.of(0, new ItemStack(Items.DEAD_BUSH, 1), 1, new ItemStack(Items.STICK, 10), 2, new ItemStack(Items.QUARTZ_BLOCK, 91), 3, new ItemStack(Items.QUARTZ, 365))
+				),
+				new InsertItemUpdatesStacksParams(
+						Map.of(0, ItemStack.EMPTY, 1, new ItemStack(Items.STICK, 1), 2, new ItemStack(Items.QUARTZ_BLOCK, 1), 3, new ItemStack(Items.QUARTZ, 1)),
+						64,
+						0,
+						new ItemStack(Items.DEAD_BUSH, 65),
+						new ItemStack(Items.DEAD_BUSH, 1),
+						Map.of(0, new ItemStack(Items.DEAD_BUSH, 64)),
+						Map.of(0, new ItemStack(Items.DEAD_BUSH, 64), 1, new ItemStack(Items.STICK, 577), 2, new ItemStack(Items.QUARTZ_BLOCK, 5194), 3, new ItemStack(Items.QUARTZ, 20777))
+
+				),
+				new InsertItemUpdatesStacksParams(
+						Map.of(0, new ItemStack(Items.DEAD_BUSH, 64), 1, new ItemStack(Items.STICK, 64), 2, new ItemStack(Items.QUARTZ_BLOCK, 64), 3, new ItemStack(Items.QUARTZ, 23)),
+						64,
+						3,
+						new ItemStack(Items.QUARTZ, 64),
+						new ItemStack(Items.QUARTZ, 23),
+						Map.of(3, new ItemStack(Items.QUARTZ, 64)),
+						Map.of(0, new ItemStack(Items.DEAD_BUSH, 64), 1, new ItemStack(Items.STICK, 640), 2, new ItemStack(Items.QUARTZ_BLOCK, 5824), 3, new ItemStack(Items.QUARTZ, 23360))
+
 				)
 		);
 	}
@@ -717,6 +759,14 @@ public class CompressionInventoryPartTest {
 						Map.of(0, new ItemStack(Items.IRON_SWORD), 1, ItemStack.EMPTY),
 						64,
 						Map.of(0, ImmutablePair.of(new ItemStack(Items.IRON_SWORD), 1), 1, ImmutablePair.of(new ItemStack(Items.IRON_SWORD), 0))
+				),
+				new StackLimitsAreSetCorrectlyOnInitParams(
+						Map.of(0, new ItemStack(Items.DEAD_BUSH), 1, ItemStack.EMPTY, 2, ItemStack.EMPTY, 3, ItemStack.EMPTY),
+						64,
+						Map.of(
+								0, ImmutablePair.of(new ItemStack(Items.DEAD_BUSH), 64), 1, ImmutablePair.of(new ItemStack(Items.STICK), 9 * 64 + 64),
+								2, ImmutablePair.of(new ItemStack(Items.QUARTZ_BLOCK), 9 * 9 * 64 + 9 * 64 + 64), 3, ImmutablePair.of(new ItemStack(Items.QUARTZ), 9 * 9 * 4 * 64 + 9 * 4 * 64 + 4 * 64 + 64)
+						)
 				)
 		);
 	}


### PR DESCRIPTION
…it if there are different multipliers for tiers of items it compresses (compressed quartz block = 9x quart block but quartz block = 4x quartz)