### PR TITLE
Fix minor typo in en_us.json

### DIFF
--- a/src/main/resources/assets/sophisticatedstorage/lang/en_us.json
+++ b/src/main/resources/assets/sophisticatedstorage/lang/en_us.json
@@ -194,7 +194,7 @@
   "item.sophisticatedstorage.hopper_upgrade": "Hopper Upgrade",
   "item.sophisticatedstorage.hopper_upgrade.tooltip": "Pulls items from block on top and/or pushes them to block below",
   "item.sophisticatedstorage.advanced_hopper_upgrade": "Advanced Hopper Upgrade",
-  "item.sophisticatedstorage.advanced_hopper_upgrade.tooltip": "Pulls items from block on top and/or pushes them to block below\nFaster and with input / ouput options",
+  "item.sophisticatedstorage.advanced_hopper_upgrade.tooltip": "Pulls items from block on top and/or pushes them to block below\nFaster and with input / output options",
   "item.sophisticatedstorage.infinity_upgrade": "Infinity Upgrade (Admin)",
   "item.sophisticatedstorage.infinity_upgrade.tooltip": "Makes all items in storage infinite\nOnly admins can set infinite items and break storage",
   "item.sophisticatedstorage.survival_infinity_upgrade": "Survival Infinity Upgrade",


### PR DESCRIPTION
Just fixed a minor typo in the en_us.json file which I came across while playing.