### PR TITLE
[1.18.x] Fix compression handling, packed barrel tooltips and display rendering

### DIFF
--- a/src/main/java/net/p3pp3rf1y/sophisticatedstorage/block/LimitedBarrelBlock.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedstorage/block/LimitedBarrelBlock.java
@@ -150,6 +150,9 @@ public class LimitedBarrelBlock extends BarrelBlock {
 			return true;
 		}
 
+		if (hand == InteractionHand.MAIN_HAND && itemInHand.isEmpty() && hitVec.getDirection() == getFacing(state)) {
+			return use(state, level, pos, player, hand, hitVec).consumesAction();
+		}
 		return tryToDyeAll(state, level, pos, hitVec, itemInHand);
 	}
 

--- a/src/main/java/net/p3pp3rf1y/sophisticatedstorage/client/ClientEventHandler.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedstorage/client/ClientEventHandler.java
@@ -47,6 +47,7 @@ import net.p3pp3rf1y.sophisticatedstorage.client.init.ModItemColors;
 import net.p3pp3rf1y.sophisticatedstorage.client.init.ModParticles;
 import net.p3pp3rf1y.sophisticatedstorage.client.render.*;
 import net.p3pp3rf1y.sophisticatedstorage.common.gui.StorageContainerMenu;
+import net.p3pp3rf1y.sophisticatedstorage.compat.compressium.CompressiumDisplayModel;
 import net.p3pp3rf1y.sophisticatedstorage.init.ModBlocks;
 import net.p3pp3rf1y.sophisticatedstorage.init.ModItems;
 import net.p3pp3rf1y.sophisticatedstorage.item.StorageContentsTooltip;
@@ -173,7 +174,7 @@ public class ClientEventHandler {
 			double mouseX = mh.xpos() * mc.getWindow().getGuiScaledWidth() / mc.getWindow().getScreenWidth();
 			double mouseY = mh.ypos() * mc.getWindow().getGuiScaledHeight() / mc.getWindow().getScreenHeight();
 			Slot selectedSlot = screen.findSlot(mouseX, mouseY);
-			if (selectedSlot != null && container.isNotPlayersInventorySlot(selectedSlot.index)) {
+			if (selectedSlot == null || container.isNotPlayersInventorySlot(selectedSlot.index)) {
 				container.sort();
 				return true;
 			}
@@ -202,6 +203,8 @@ public class ClientEventHandler {
 
 	private static void onRegisterReloadListeners(RegisterClientReloadListenersEvent event) {
 		event.registerReloadListener((ResourceManagerReloadListener) resourceManager -> {
+			CompressiumDisplayModel.clearCache();
+			LimitedBarrelRenderer.clearCountCache();
 			BarrelDynamicModelBase.invalidateCache();
 			BarrelBakedModelBase.invalidateCache();
 		});

--- a/src/main/java/net/p3pp3rf1y/sophisticatedstorage/client/render/BarrelBakedModelBase.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedstorage/client/render/BarrelBakedModelBase.java
@@ -513,7 +513,7 @@ public abstract class BarrelBakedModelBase implements IDynamicBakedModel {
 					continue;
 				}
 
-				BakedModel model = itemRenderer.getModel(item, null, minecraft.player, 0);
+				BakedModel model = BarrelDisplayItem.getModel(item, itemRenderer.getModel(item, null, minecraft.player, 0));
 				if (!model.isCustomRenderer()) {
 					int rotation = displayItem.getRotation();
 					for (Direction face : Direction.values()) {
@@ -604,7 +604,7 @@ public abstract class BarrelBakedModelBase implements IDynamicBakedModel {
 		QuadTransformer transformer = directionCache.getIfPresent(hash);
 
 		if (transformer == null) {
-			double offset = DisplayItemRenderer.getDisplayItemOffset(displayItem, model, itemScale);
+			double offset = BarrelDisplayItem.getOffset(displayItem, model, itemScale);
 			if (!isFlatTop) {
 				offset -= 1 / 16D;
 			}

--- a/src/main/java/net/p3pp3rf1y/sophisticatedstorage/client/render/BarrelDisplayItem.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedstorage/client/render/BarrelDisplayItem.java
@@ -1,0 +1,25 @@
+package net.p3pp3rf1y.sophisticatedstorage.client.render;
+
+import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.p3pp3rf1y.sophisticatedstorage.compat.compressium.CompressiumDisplayModel;
+
+public class BarrelDisplayItem {
+	private BarrelDisplayItem() {}
+
+	public static BakedModel getModel(ItemStack stack, BakedModel model) {
+		return CompressiumDisplayModel.wrap(stack, SporeBlossomDisplayModel.wrap(stack, model));
+	}
+
+	public static double getOffset(ItemStack stack, BakedModel model, float scale) {
+		double offset = DisplayItemRenderer.getDisplayItemOffset(stack, model, scale);
+		if (stack.is(Items.BIG_DRIPLEAF)) {
+			return offset + 6 / 16D * scale;
+		}
+		if (stack.is(Items.SMALL_DRIPLEAF)) {
+			return offset + 4 / 16D * scale;
+		}
+		return offset;
+	}
+}

--- a/src/main/java/net/p3pp3rf1y/sophisticatedstorage/client/render/ClientStorageContentsTooltip.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedstorage/client/render/ClientStorageContentsTooltip.java
@@ -1,18 +1,31 @@
 package net.p3pp3rf1y.sophisticatedstorage.client.render;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.renderer.entity.ItemRenderer;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.event.world.WorldEvent;
+import net.p3pp3rf1y.sophisticatedcore.api.IStorageWrapper;
+import net.p3pp3rf1y.sophisticatedstorage.block.BarrelBlock;
+import net.p3pp3rf1y.sophisticatedstorage.block.LimitedBarrelBlock;
 import net.p3pp3rf1y.sophisticatedstorage.item.CapabilityStorageWrapper;
 import net.p3pp3rf1y.sophisticatedstorage.item.StorageContentsTooltip;
+import net.p3pp3rf1y.sophisticatedstorage.item.StorageContentsWrapper;
+import net.p3pp3rf1y.sophisticatedstorage.item.WoodStorageBlockItem;
 import net.p3pp3rf1y.sophisticatedstorage.network.RequestStorageContentsMessage;
 import net.p3pp3rf1y.sophisticatedstorage.network.StoragePacketHandler;
 
+import java.util.List;
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class ClientStorageContentsTooltip extends net.p3pp3rf1y.sophisticatedcore.client.render.ClientStorageContentsTooltip {
+	private static final Pattern BARREL_TIER = Pattern.compile("^(?:limited_)?(?:(copper|iron|gold|diamond|netherite)_)?barrel(?:_[1-4])?$");
 	private final ItemStack storageItem;
 
 	@SuppressWarnings("unused") //parameter needs to be there so that addListener logic would know which event this method listens to
@@ -28,6 +41,32 @@ public class ClientStorageContentsTooltip extends net.p3pp3rf1y.sophisticatedcor
 
 	public ClientStorageContentsTooltip(StorageContentsTooltip tooltip) {
 		storageItem = tooltip.getStorageItem();
+	}
+
+	@Override
+	protected IStorageWrapper refreshContentsWrapper(IStorageWrapper wrapper) {
+		return StorageContentsWrapper.fromStack(storageItem).orElseGet(() -> super.refreshContentsWrapper(wrapper));
+	}
+
+	@Override
+	protected List<ItemStack> getContents(IStorageWrapper wrapper) {
+		if (!(wrapper instanceof StorageContentsWrapper preview) || !(storageItem.getItem() instanceof BlockItem blockItem) || !(blockItem.getBlock() instanceof LimitedBarrelBlock)) {
+			return super.getContents(wrapper);
+		}
+		return preview.getContents();
+	}
+
+	@Override
+	protected void addTooltipLines(IStorageWrapper wrapper, List<Component> lines) {
+		if (!WoodStorageBlockItem.isPacked(storageItem) || !(storageItem.getItem() instanceof BlockItem blockItem) || !(blockItem.getBlock() instanceof BarrelBlock barrel) || barrel.getRegistryName() == null) {
+			return;
+		}
+		Matcher matcher = BARREL_TIER.matcher(barrel.getRegistryName().getPath());
+		if (matcher.matches()) {
+			String tier = matcher.group(1) == null ? "wood" : matcher.group(1);
+			lines.add(new TranslatableComponent("item.sophisticatedstorage.barrel.tooltip.tier",
+					new TranslatableComponent("storage_tier.sophisticatedstorage." + tier).withStyle(ChatFormatting.WHITE)).withStyle(ChatFormatting.GRAY));
+		}
 	}
 
 	@Override

--- a/src/main/java/net/p3pp3rf1y/sophisticatedstorage/client/render/DisplayItemRenderer.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedstorage/client/render/DisplayItemRenderer.java
@@ -25,8 +25,10 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 import net.minecraftforge.client.model.data.EmptyModelData;
 import net.p3pp3rf1y.sophisticatedcore.inventory.ItemStackKey;
 import net.p3pp3rf1y.sophisticatedcore.renderdata.RenderInfo;
+import net.p3pp3rf1y.sophisticatedstorage.block.BarrelBlock;
 import net.p3pp3rf1y.sophisticatedstorage.block.StorageBlockBase;
 import net.p3pp3rf1y.sophisticatedstorage.block.StorageBlockEntity;
+import net.p3pp3rf1y.sophisticatedstorage.compat.compressium.CompressiumDisplayModel;
 import net.p3pp3rf1y.sophisticatedstorage.init.ModItems;
 
 import java.util.HashSet;
@@ -56,7 +58,7 @@ public class DisplayItemRenderer {
 
 	public void renderDisplayItem(StorageBlockEntity blockEntity, PoseStack poseStack, MultiBufferSource bufferSource, int packedLight, int packedOverlay) {
 		blockEntity.getStorageWrapper().getRenderInfo().getItemDisplayRenderInfo().getDisplayItem().ifPresent(displayItem ->
-				renderSingleItem(poseStack, bufferSource, packedLight, packedOverlay, Minecraft.getInstance(), false, 0, 1, displayItem.getItem(), displayItem.getRotation()));
+				renderSingleItem(poseStack, bufferSource, packedLight, packedOverlay, Minecraft.getInstance(), false, blockEntity.getBlockState().getBlock() instanceof BarrelBlock, 0, 1, displayItem.getItem(), displayItem.getRotation()));
 	}
 
 	public void renderDisplayItems(StorageBlockEntity blockEntity, PoseStack poseStack, MultiBufferSource bufferSource, int packedLight, int packedOverlay, boolean renderOnlyCustom) {
@@ -76,12 +78,12 @@ public class DisplayItemRenderer {
 		int displayItemCount = storageBlock.getDisplayItemsCount(displayItems);
 		for (int displayItemIndex = 0; displayItemIndex < displayItemCount; displayItemIndex++) {
 			if (inaccessibleSlots.contains(displayItemIndex)) {
-				renderSingleItem(poseStack, bufferSource, packedLight, packedOverlay, minecraft, renderOnlyCustom, displayItemIndex, displayItemCount, INACCESSIBLE_SLOT_STACK, 0);
+				renderSingleItem(poseStack, bufferSource, packedLight, packedOverlay, minecraft, renderOnlyCustom, storageBlock instanceof BarrelBlock, displayItemIndex, displayItemCount, INACCESSIBLE_SLOT_STACK, 0);
 			}
 		}
 		int displayItemIndex = 0;
 		for (RenderInfo.DisplayItem displayItem : displayItems) {
-			renderSingleItem(poseStack, bufferSource, packedLight, packedOverlay, minecraft, renderOnlyCustom, storageBlock.hasFixedIndexDisplayItems() ? displayItem.getSlotIndex() : displayItemIndex, displayItemCount, displayItem.getItem(), displayItem.getRotation());
+			renderSingleItem(poseStack, bufferSource, packedLight, packedOverlay, minecraft, renderOnlyCustom, storageBlock instanceof BarrelBlock, storageBlock.hasFixedIndexDisplayItems() ? displayItem.getSlotIndex() : displayItemIndex, displayItemCount, displayItem.getItem(), displayItem.getRotation());
 			displayItemIndex++;
 		}
 	}
@@ -120,16 +122,20 @@ public class DisplayItemRenderer {
 		poseStack.popPose();
 	}
 
-	private void renderSingleItem(PoseStack poseStack, MultiBufferSource bufferSource, int packedLight, int packedOverlay, Minecraft minecraft, boolean renderOnlyCustom, int displayItemIndex, int displayItemCount, ItemStack stack, int rotation) {
+	private void renderSingleItem(PoseStack poseStack, MultiBufferSource bufferSource, int packedLight, int packedOverlay, Minecraft minecraft, boolean renderOnlyCustom, boolean isBarrel, int displayItemIndex, int displayItemCount, ItemStack stack, int rotation) {
 		if (stack.isEmpty()) {
 			return;
 		}
 		BakedModel itemModel = minecraft.getItemRenderer().getModel(stack, null, minecraft.player, 0);
+		if (isBarrel) {
+			itemModel = BarrelDisplayItem.getModel(stack, itemModel);
+		}
 		if (!itemModel.isCustomRenderer() && renderOnlyCustom) {
 			return;
 		}
 
-		float itemOffset = (float) getDisplayItemOffset(stack, itemModel, displayItemCount == 1 ? 1 : SMALL_3D_ITEM_SCALE);
+		float scale = displayItemCount == 1 ? 1 : SMALL_3D_ITEM_SCALE;
+		float itemOffset = (float) (isBarrel ? BarrelDisplayItem.getOffset(stack, itemModel, scale) : getDisplayItemOffset(stack, itemModel, scale));
 		poseStack.pushPose();
 
 		Vector3f frontOffset = getDisplayItemIndexFrontOffset(displayItemIndex, displayItemCount, (float) yCenterTranslation);
@@ -149,12 +155,18 @@ public class DisplayItemRenderer {
 	}
 
 	public static double getDisplayItemOffset(ItemStack item, BakedModel itemModel, float additionalScale) {
-		int hash = ItemStackKey.getHashCode(item) * 31 + Float.hashCode(additionalScale);
+		if (itemModel instanceof SporeBlossomDisplayModel) {
+			return SporeBlossomDisplayModel.FACE_CLEARANCE;
+		}
+		int hash = (ItemStackKey.getHashCode(item) * 31 + Float.hashCode(additionalScale)) * 31 + System.identityHashCode(itemModel);
 		Double offset = ITEM_HASHCODE_OFFSETS.getIfPresent(hash);
 		if (offset != null) {
 			return offset;
 		}
 		offset = calculateDisplayItemOffset(item, itemModel, additionalScale);
+		if (itemModel instanceof CompressiumDisplayModel) {
+			offset += 1 / 64D;
+		}
 		ITEM_HASHCODE_OFFSETS.put(hash, offset);
 		return offset;
 	}

--- a/src/main/java/net/p3pp3rf1y/sophisticatedstorage/client/render/LimitedBarrelRenderer.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedstorage/client/render/LimitedBarrelRenderer.java
@@ -1,8 +1,11 @@
 package net.p3pp3rf1y.sophisticatedstorage.client.render;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import com.mojang.math.Vector3f;
+import com.mojang.math.Vector4f;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.renderer.MultiBufferSource;
@@ -10,9 +13,9 @@ import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.resources.model.Material;
 import net.minecraft.core.Direction;
-import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.chat.Style;
 import net.minecraft.network.chat.TextComponent;
+import net.minecraft.util.FormattedCharSequence;
 import net.minecraft.world.inventory.InventoryMenu;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
@@ -34,6 +37,8 @@ public class LimitedBarrelRenderer extends BarrelRenderer<LimitedBarrelBlockEnti
 	private static final float MULTIPLE_ITEMS_FONT_SCALE = 1 / 96f;
 	private static final float SINGLE_ITEM_FONT_SCALE = 1 / 48f;
 	private static final Style COUNT_DISPLAY_STYLE = Style.EMPTY.withFont(UNIFORM_FONT).withBold(true);
+	private static final Cache<Long, CountLabel> COUNT_LABELS = CacheBuilder.newBuilder().maximumSize(4096).build();
+	private static Font cachedFont;
 	private final DisplayItemRenderer displayItemRenderer = new DisplayItemRenderer(0.5, new Vec3(0, 0, -1 / 16D));
 	private final DisplayItemRenderer flatDisplayItemRenderer = new DisplayItemRenderer(0.5, Vec3.ZERO);
 
@@ -162,23 +167,43 @@ public class LimitedBarrelRenderer extends BarrelRenderer<LimitedBarrelBlockEnti
 
 			float scale = slotCounts.size() == 1 ? SINGLE_ITEM_FONT_SCALE : MULTIPLE_ITEMS_FONT_SCALE;
 			poseStack.scale(scale, -scale, scale);
-			MutableComponent countString = new TextComponent(CountAbbreviator.abbreviate(count, slotCounts.size() == 1 ? 6 : 5)).withStyle(COUNT_DISPLAY_STYLE);
 			Font font = Minecraft.getInstance().font;
-			float countDisplayXOffset = -font.getSplitter().stringWidth(countString) / 2f;
-			poseStack.translate(countDisplayXOffset, 0, 0);
-			font.drawInBatch(countString, 0, 0, blockEntity.getSlotColor(displayItemIndex), false, poseStack.last().pose(), bufferSource, false, 0, packedLight);
+			CountLabel label = getCountLabel(font, count, slotCounts.size() == 1 ? 6 : 5);
+			poseStack.translate(-label.width() / 2f, 0, 0);
+			font.drawInBatch(label.text(), 0, 0, blockEntity.getSlotColor(displayItemIndex), false, poseStack.last().pose(), bufferSource, false, 0, packedLight);
 
 			poseStack.popPose();
 		}
 		poseStack.popPose();
 	}
 
+	public static void clearCountCache() {
+		COUNT_LABELS.invalidateAll();
+		cachedFont = null;
+	}
+
+	static CountLabel getCountLabel(Font font, int count, int maxCharacters) {
+		if (cachedFont != font) {
+			clearCountCache();
+			cachedFont = font;
+		}
+		long key = ((long) maxCharacters << 32) | (count & 0xFFFFFFFFL);
+		CountLabel label = COUNT_LABELS.getIfPresent(key);
+		if (label == null) {
+			FormattedCharSequence text = new TextComponent(CountAbbreviator.abbreviate(count, maxCharacters)).withStyle(COUNT_DISPLAY_STYLE).getVisualOrderText();
+			label = new CountLabel(text, font.getSplitter().stringWidth(text));
+			COUNT_LABELS.put(key, label);
+		}
+		return label;
+	}
+
+	record CountLabel(FormattedCharSequence text, float width) {}
+
 	private void renderFillLevel(PoseStack poseStack, MultiBufferSource bufferSource, int packedLight, int packedOverlay, float fillLevel, float x, float y, boolean large, boolean translucentRender) {
 		poseStack.pushPose();
 		poseStack.translate(x + 1/16F/5F, y + 1/16F/5F, 0);
 		int barHeight = large ? 14 : 6;
 		poseStack.scale(1 / 16F / 5F * 3, fillLevel * 1 / 16F / 5F * (barHeight * 5 - 2), 1);
-		poseStack.pushPose();
 		VertexConsumer vertexConsumer;
 		if (translucentRender) {
 			//noinspection resource
@@ -188,13 +213,31 @@ public class LimitedBarrelRenderer extends BarrelRenderer<LimitedBarrelBlockEnti
 			vertexConsumer = FILL_INDICATORS_TEXTURE.buffer(bufferSource, RenderType::entityCutoutNoCull);
 		}
 		PoseStack.Pose pose = poseStack.last();
+		Vector4f position = new Vector4f();
 		Vector3f normal = new Vector3f(0, 1, 0);
 		normal.transform(pose.normal());
 		float minU = large ? 0 : 3 / 128F;
 		float maxV = large ? 68 / 128F : 28 / 128F;
-		RenderHelper.renderQuad(vertexConsumer, pose.pose(), normal, packedOverlay, packedLight, translucentRender ? 0.5F : 1, minU, (1 - fillLevel) * maxV, minU + 3 / 128F, maxV);
+		float maxU = minU + 3 / 128F;
+		float minV = (1 - fillLevel) * maxV;
+		float alpha = translucentRender ? 0.5F : 1;
+		renderFillVertex(vertexConsumer, pose, position, normal, 0, 1, maxU, minV, alpha, packedOverlay, packedLight);
+		renderFillVertex(vertexConsumer, pose, position, normal, 0, 0, maxU, maxV, alpha, packedOverlay, packedLight);
+		renderFillVertex(vertexConsumer, pose, position, normal, 1, 0, minU, maxV, alpha, packedOverlay, packedLight);
+		renderFillVertex(vertexConsumer, pose, position, normal, 1, 1, minU, minV, alpha, packedOverlay, packedLight);
 
 		poseStack.popPose();
-		poseStack.popPose();
+	}
+
+	static void renderFillVertex(VertexConsumer consumer, PoseStack.Pose pose, Vector4f position, Vector3f normal, float x, float y, float u, float v, float alpha, int packedOverlay, int packedLight) {
+		position.set(x, y, 0, 1);
+		position.transform(pose.pose());
+		consumer.vertex(position.x(), position.y(), position.z());
+		consumer.color(1, 1, 1, alpha);
+		consumer.uv(u, v);
+		consumer.overlayCoords(packedOverlay);
+		consumer.uv2(packedLight);
+		consumer.normal(normal.x(), normal.y(), normal.z());
+		consumer.endVertex();
 	}
 }

--- a/src/main/java/net/p3pp3rf1y/sophisticatedstorage/client/render/SporeBlossomDisplayModel.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedstorage/client/render/SporeBlossomDisplayModel.java
@@ -1,0 +1,51 @@
+package net.p3pp3rf1y.sophisticatedstorage.client.render;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.math.Vector3f;
+import net.minecraft.client.renderer.block.model.ItemTransform;
+import net.minecraft.client.renderer.block.model.ItemTransforms;
+import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraftforge.client.ForgeHooksClient;
+import net.minecraftforge.client.model.BakedModelWrapper;
+
+public final class SporeBlossomDisplayModel extends BakedModelWrapper<BakedModel> {
+	public static final double FACE_CLEARANCE = 1.0 / 1024.0;
+	private static final float ATTACHMENT_Y = 15.9F / 16.0F;
+	private final ItemTransforms transforms;
+
+	private SporeBlossomDisplayModel(BakedModel original) {
+		super(original);
+		ItemTransforms source = original.getTransforms();
+		Vector3f scale = source.getTransform(ItemTransforms.TransformType.FIXED).scale;
+		ItemTransform fixed = new ItemTransform(new Vector3f(90, 0, 0),
+				new Vector3f(0, 0, -(ATTACHMENT_Y - 0.5F) * scale.y()), scale);
+		transforms = new ItemTransforms(source.thirdPersonLeftHand, source.thirdPersonRightHand,
+				source.firstPersonLeftHand, source.firstPersonRightHand, source.head,
+				source.gui, source.ground, fixed, source.moddedTransforms);
+	}
+
+	public static BakedModel wrap(ItemStack stack, BakedModel model) {
+		return stack.is(Items.SPORE_BLOSSOM) && !(model instanceof SporeBlossomDisplayModel)
+				? new SporeBlossomDisplayModel(model) : model;
+	}
+
+	@Override
+	public ItemTransforms getTransforms() {
+		return transforms;
+	}
+
+	@Override
+	public boolean doesHandlePerspectives() {
+		return true;
+	}
+
+	@Override
+	public BakedModel handlePerspective(ItemTransforms.TransformType type, PoseStack poseStack) {
+		if (type == ItemTransforms.TransformType.FIXED) {
+			return ForgeHooksClient.handlePerspective(this, type, poseStack);
+		}
+		return originalModel.handlePerspective(type, poseStack);
+	}
+}

--- a/src/main/java/net/p3pp3rf1y/sophisticatedstorage/common/CommonEventHandler.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedstorage/common/CommonEventHandler.java
@@ -7,6 +7,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TextComponent;
 import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
@@ -74,6 +75,7 @@ public class CommonEventHandler {
 			return;
 		}
 		if (sneakItemInteractionBlock.trySneakItemInteraction(event.getPlayer(), event.getHand(), state, level, pos, event.getHitVec(), event.getItemStack())) {
+			event.setCancellationResult(InteractionResult.sidedSuccess(level.isClientSide));
 			event.setCanceled(true);
 		}
 	}

--- a/src/main/java/net/p3pp3rf1y/sophisticatedstorage/compat/compressium/CompressiumDisplayModel.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedstorage/compat/compressium/CompressiumDisplayModel.java
@@ -1,0 +1,204 @@
+package net.p3pp3rf1y.sophisticatedstorage.compat.compressium;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.mojang.blaze3d.platform.NativeImage;
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.math.Vector3f;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.block.model.BakedQuad;
+import net.minecraft.client.renderer.block.model.BlockElementFace;
+import net.minecraft.client.renderer.block.model.BlockFaceUV;
+import net.minecraft.client.renderer.block.model.FaceBakery;
+import net.minecraft.client.renderer.block.model.ItemTransform;
+import net.minecraft.client.renderer.block.model.ItemTransforms;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.client.resources.model.BlockModelRotation;
+import net.minecraft.core.Direction;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.packs.resources.Resource;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.client.ForgeHooksClient;
+import net.minecraftforge.client.model.BakedModelWrapper;
+import net.minecraftforge.client.model.data.IModelData;
+import net.minecraftforge.fml.ModList;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+public class CompressiumDisplayModel extends BakedModelWrapper<BakedModel> {
+	private static final ResourceLocation MODEL_LOCATION = new ResourceLocation("sophisticatedstorage", "compressium_display");
+	private static final FaceBakery FACE_BAKERY = new FaceBakery();
+	private static final Cache<ModelKey, BakedModel> MODELS = CacheBuilder.newBuilder().expireAfterAccess(30, TimeUnit.MINUTES).build();
+	private final Map<Direction, List<BakedQuad>> quads = new EnumMap<>(Direction.class);
+	private final ItemTransforms transforms;
+
+	private CompressiumDisplayModel(BakedModel original, AlphaMask mask) {
+		super(original);
+		for (Direction direction : Direction.values()) {
+			quads.put(direction, bakeFaceQuads(original.getParticleIcon(), mask, direction));
+		}
+		ItemTransforms source = original.getTransforms();
+		ItemTransform fixed = source.getTransform(ItemTransforms.TransformType.FIXED);
+		Vector3f scale = fixed.scale.copy();
+		scale.mul(0.5f);
+		Vector3f translation = fixed.translation.copy();
+		translation.mul(0.5f);
+		transforms = new ItemTransforms(source.thirdPersonLeftHand, source.thirdPersonRightHand, source.firstPersonLeftHand,
+				source.firstPersonRightHand, source.head, source.gui, source.ground, new ItemTransform(fixed.rotation, translation, scale), source.moddedTransforms);
+	}
+
+	public static BakedModel wrap(ItemStack stack, BakedModel model) {
+		if (!ModList.get().isLoaded("compressium") || !(stack.getItem() instanceof BlockItem) || model instanceof CompressiumDisplayModel) {
+			return model;
+		}
+		ResourceLocation name = stack.getItem().getRegistryName();
+		if (name == null || !"compressium".equals(name.getNamespace())) {
+			return model;
+		}
+		ModelKey key = new ModelKey(model, name);
+		BakedModel cached = MODELS.getIfPresent(key);
+		if (cached != null) {
+			return cached;
+		}
+		BakedModel replacement = loadModel(name, model);
+		MODELS.put(key, replacement);
+		return replacement;
+	}
+
+	private static BakedModel loadModel(ResourceLocation name, BakedModel original) {
+		String path = name.getPath();
+		int separator = path.lastIndexOf('_');
+		if (separator < 0) {
+			return original;
+		}
+		try {
+			int tier = Integer.parseInt(path.substring(separator + 1));
+			if (tier < 1 || tier > 9) {
+				return original;
+			}
+			ResourceLocation texture = new ResourceLocation("compressium", "textures/block/layer_" + tier + ".png");
+			try (Resource resource = Minecraft.getInstance().getResourceManager().getResource(texture);
+					NativeImage image = NativeImage.read(resource.getInputStream())) {
+				int[] alpha = new int[image.getWidth() * image.getHeight()];
+				for (int y = 0; y < image.getHeight(); y++) {
+					for (int x = 0; x < image.getWidth(); x++) {
+						alpha[y * image.getWidth() + x] = NativeImage.getA(image.getPixelRGBA(x, y));
+					}
+				}
+				return new CompressiumDisplayModel(original, new AlphaMask(image.getWidth(), image.getHeight(), alpha));
+			}
+		} catch (IOException | NumberFormatException e) {
+			return original;
+		}
+	}
+
+	public static void clearCache() {
+		MODELS.invalidateAll();
+	}
+
+	@Override
+	public List<BakedQuad> getQuads(@Nullable BlockState state, @Nullable Direction side, Random random) {
+		return side == null ? List.of() : quads.get(side);
+	}
+
+	@Override
+	public List<BakedQuad> getQuads(@Nullable BlockState state, @Nullable Direction side, Random random, IModelData data) {
+		return getQuads(state, side, random);
+	}
+
+	@Override
+	public boolean isCustomRenderer() {
+		return false;
+	}
+
+	@Override
+	public boolean isGui3d() {
+		return true;
+	}
+
+	@Override
+	public ItemTransforms getTransforms() {
+		return transforms;
+	}
+
+	@Override
+	public boolean doesHandlePerspectives() {
+		return true;
+	}
+
+	@Override
+	public BakedModel handlePerspective(ItemTransforms.TransformType type, PoseStack poseStack) {
+		return type == ItemTransforms.TransformType.FIXED ? ForgeHooksClient.handlePerspective(this, type, poseStack) : originalModel.handlePerspective(type, poseStack);
+	}
+
+	private static List<BakedQuad> bakeFaceQuads(TextureAtlasSprite baseSprite, AlphaMask alphaMask, Direction direction) {
+		List<BakedQuad> quads = new ArrayList<>(alphaMask.width() * alphaMask.height());
+		float step = 16.0F / alphaMask.width();
+		float verticalStep = 16.0F / alphaMask.height();
+		for (int y = 0; y < alphaMask.height(); y++) {
+			for (int x = 0; x < alphaMask.width(); x++) {
+				int alpha = alphaMask.alpha(x, y);
+				float x0 = x * step;
+				float x1 = (x + 1) * step;
+				float y0 = 16.0F - (y + 1) * verticalStep;
+				float y1 = 16.0F - y * verticalStep;
+				float u0 = x * step;
+				float u1 = (x + 1) * step;
+				float v0 = y * verticalStep;
+				float v1 = (y + 1) * verticalStep;
+				int multiplier = Math.max(0, 255 - alpha);
+				quads.add(withVertexColor(bakeFaceQuad(baseSprite, direction, x0, y0, x1, y1, u0, v0, u1, v1), grayVertexColor(multiplier)));
+			}
+		}
+		return quads;
+	}
+
+	private static BakedQuad bakeFaceQuad(TextureAtlasSprite sprite, Direction direction, float x0, float y0, float x1, float y1, float u0, float v0, float u1, float v1) {
+		Vector3f from;
+		Vector3f to;
+		if (direction == Direction.UP || direction == Direction.DOWN) {
+			from = new Vector3f(x0, 0.0F, y0);
+			to = new Vector3f(x1, 16.0F, y1);
+		} else if (direction == Direction.EAST || direction == Direction.WEST) {
+			from = new Vector3f(0.0F, y0, x0);
+			to = new Vector3f(16.0F, y1, x1);
+		} else {
+			from = new Vector3f(x0, y0, 0.0F);
+			to = new Vector3f(x1, y1, 16.0F);
+		}
+		return FACE_BAKERY.bakeQuad(from, to,
+				new BlockElementFace(null, -1, "", new BlockFaceUV(new float[] {u0, v0, u1, v1}, 0)),
+				sprite, direction, BlockModelRotation.X0_Y0, null, true, MODEL_LOCATION);
+	}
+
+	private static BakedQuad withVertexColor(BakedQuad quad, int color) {
+		int[] vertices = quad.getVertices().clone();
+		for (int vertex = 0; vertex < 4; vertex++) {
+			vertices[vertex * 8 + 3] = color;
+		}
+		return new BakedQuad(vertices, quad.getTintIndex(), quad.getDirection(), quad.getSprite(), quad.isShade());
+	}
+
+	private static int grayVertexColor(int value) {
+		int clamped = Math.max(0, Math.min(255, value));
+		return 0xFF000000 | (clamped << 16) | (clamped << 8) | clamped;
+	}
+
+	private record ModelKey(BakedModel original, ResourceLocation item) {}
+
+	private record AlphaMask(int width, int height, int[] alpha) {
+		int alpha(int x, int y) {
+			return alpha[y * width + x];
+		}
+	}
+}

--- a/src/main/java/net/p3pp3rf1y/sophisticatedstorage/item/StorageContentsWrapper.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedstorage/item/StorageContentsWrapper.java
@@ -1,0 +1,103 @@
+package net.p3pp3rf1y.sophisticatedstorage.item;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.Tag;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.TextComponent;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.ItemStack;
+import net.p3pp3rf1y.sophisticatedcore.api.IStorageWrapper;
+import net.p3pp3rf1y.sophisticatedcore.inventory.InventoryHandler;
+import net.p3pp3rf1y.sophisticatedcore.upgrades.UpgradeHandler;
+import net.p3pp3rf1y.sophisticatedcore.util.NBTHelper;
+import net.p3pp3rf1y.sophisticatedstorage.block.BarrelBlock;
+import net.p3pp3rf1y.sophisticatedstorage.block.IStorageBlock;
+import net.p3pp3rf1y.sophisticatedstorage.block.ItemContentsStorage;
+import net.p3pp3rf1y.sophisticatedstorage.block.StorageBlockEntity;
+import net.p3pp3rf1y.sophisticatedstorage.block.StorageWrapper;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public class StorageContentsWrapper extends StorageWrapper {
+	private final IStorageBlock storageBlock;
+
+	StorageContentsWrapper(IStorageBlock storageBlock, CompoundTag tag) {
+		super(() -> () -> {}, () -> {}, () -> {}, storageBlock.getNumberOfInventorySlots());
+		this.storageBlock = storageBlock;
+		load(tag.copy());
+		onInit();
+	}
+
+	public static Optional<IStorageWrapper> fromStack(ItemStack stack) {
+		if (!WoodStorageBlockItem.isPacked(stack) || !(stack.getItem() instanceof BlockItem blockItem) || !(blockItem.getBlock() instanceof BarrelBlock barrel)) {
+			return Optional.empty();
+		}
+		return NBTHelper.getUniqueId(stack, "uuid").flatMap(uuid -> {
+			CompoundTag saved = ItemContentsStorage.get().getOrCreateStorageContents(uuid);
+			CompoundTag wrapperTag = saved.getCompound(StorageBlockEntity.STORAGE_WRAPPER_TAG);
+			CompoundTag contents = wrapperTag.getCompound(CONTENTS_TAG);
+			if (!contents.contains(InventoryHandler.INVENTORY_TAG, Tag.TAG_COMPOUND)
+					&& !contents.contains(UpgradeHandler.UPGRADE_INVENTORY_TAG, Tag.TAG_COMPOUND)
+					&& !wrapperTag.contains("numberOfInventorySlots", Tag.TAG_INT)
+					&& !wrapperTag.contains("numberOfUpgradeSlots", Tag.TAG_INT)) {
+				return Optional.empty();
+			}
+			return Optional.of(new StorageContentsWrapper(barrel, wrapperTag));
+		});
+	}
+
+	public List<ItemStack> getContents() {
+		List<ItemStack> contents = new ArrayList<>();
+		InventoryHandler inventory = getInventoryHandler();
+		for (int slot = 0; slot < inventory.getSlots(); slot++) {
+			ItemStack stack = inventory.getStackInSlot(slot);
+			if (!stack.isEmpty()) {
+				contents.add(stack.copy());
+			}
+		}
+		return contents;
+	}
+
+	@Override
+	public int getDefaultNumberOfInventorySlots() {
+		return storageBlock.getNumberOfInventorySlots();
+	}
+
+	@Override
+	public int getDefaultNumberOfUpgradeSlots() {
+		return storageBlock.getNumberOfUpgradeSlots();
+	}
+
+	@Override
+	public int getBaseStackSizeMultiplier() {
+		return storageBlock.getBaseStackSizeMultiplier();
+	}
+
+	@Override
+	public Optional<UUID> getContentsUuid() {
+		return Optional.ofNullable(contentsUuid);
+	}
+
+	@Override
+	protected boolean isAllowedInStorage(ItemStack stack) {
+		return false;
+	}
+
+	@Override
+	protected void onUpgradeRefresh() {
+		//noop
+	}
+
+	@Override
+	public String getStorageType() {
+		return "wood_storage";
+	}
+
+	@Override
+	public Component getDisplayName() {
+		return TextComponent.EMPTY;
+	}
+}

--- a/src/main/java/net/p3pp3rf1y/sophisticatedstorage/upgrades/compression/CompressionInventoryPart.java
+++ b/src/main/java/net/p3pp3rf1y/sophisticatedstorage/upgrades/compression/CompressionInventoryPart.java
@@ -42,6 +42,8 @@ public class CompressionInventoryPart implements IInventoryPartHandler {
 
 	private Map<Integer, SlotDefinition> slotDefinitions = new HashMap<>();
 	private final Map<Integer, ItemStack> calculatedStacks = new HashMap<>();
+	private final Map<Integer, Integer> lastCalculatedCounts = new HashMap<>();
+	private boolean isReconcilingStacks = false;
 
 	public CompressionInventoryPart(InventoryHandler parent, InventoryPartitioner.SlotRange slotRange, Supplier<MemorySettingsCategory> getMemorySettings) {
 		this.parent = parent;
@@ -117,14 +119,11 @@ public class CompressionInventoryPart implements IInventoryPartHandler {
 	}
 
 	private void updateSlotLimits(Map<Integer, SlotDefinition> definitions) {
-		int lastMultiplier = 1;
 		int totalLimit = 0;
 		for (int slot = slotRange.firstSlot(); slot < slotRange.firstSlot() + slotRange.numberOfSlots(); slot++) {
 			if (definitions.containsKey(slot) && definitions.get(slot).isAccessible()) {
-				if (slot != slotRange.firstSlot()) {
-					lastMultiplier = intMaxCappedMultiply(lastMultiplier, definitions.get(slot).prevSlotMultiplier);
-				}
-				totalLimit = intMaxCappedAddition(totalLimit, intMaxCappedMultiply(lastMultiplier, parent.getBaseStackLimit(new ItemStack(definitions.get(slot).item))));
+				SlotDefinition definition = definitions.get(slot);
+				totalLimit = intMaxCappedAddition(parent.getBaseStackLimit(new ItemStack(definition.item)), intMaxCappedMultiply(definition.prevSlotMultiplier, totalLimit));
 
 				definitions.get(slot).setSlotLimit(totalLimit);
 			}
@@ -140,7 +139,7 @@ public class CompressionInventoryPart implements IInventoryPartHandler {
 				continue;
 			}
 			if (!slotDefinition.isCompressible()) {
-				calculatedStacks.put(slot, parent.getSlotStack(slot).copy());
+				setCalculatedStack(slot, parent.getSlotStack(slot).copy());
 				continue;
 			}
 			int internalCount = parent.getSlotStack(slot).getCount();
@@ -154,10 +153,15 @@ public class CompressionInventoryPart implements IInventoryPartHandler {
 			if (Integer.MAX_VALUE - totalCalculated < maxStackSize) {
 				calculatedStack.setCount(Integer.MAX_VALUE - (prevFull ? Math.min(maxStackSize, internalLimit - internalCount) : maxStackSize));
 			}
-			calculatedStacks.put(slot, calculatedStack);
+			setCalculatedStack(slot, calculatedStack);
 
 			prevFull = internalLimit <= internalCount;
 		}
+	}
+
+	private void setCalculatedStack(int slot, ItemStack stack) {
+		calculatedStacks.put(slot, stack);
+		lastCalculatedCounts.put(slot, stack.getCount());
 	}
 
 	private void compactInternalSlots() {
@@ -204,6 +208,7 @@ public class CompressionInventoryPart implements IInventoryPartHandler {
 	private void clearCollections() {
 		slotDefinitions.clear();
 		calculatedStacks.clear();
+		lastCalculatedCounts.clear();
 		parent.onFilterItemsChanged();
 	}
 
@@ -289,8 +294,18 @@ public class CompressionInventoryPart implements IInventoryPartHandler {
 	}
 
 	@Override
+	public boolean canCompact() {
+		return false;
+	}
+
+	@Override
 	public ItemStack extractItem(int slot, int amount, boolean simulate) {
-		return extractItem(slot, amount, simulate, ItemStack::getMaxStackSize);
+		return extractItemIgnoringLimit(slot, amount, simulate);
+	}
+
+	@Override
+	public ItemStack extractItemIgnoringLimit(int slot, int amount, boolean simulate) {
+		return extractItem(slot, amount, simulate, stack -> Integer.MAX_VALUE);
 	}
 
 	private ItemStack extractItem(int slot, int amount, boolean simulate, ToIntFunction<ItemStack> getLimit) {
@@ -302,7 +317,7 @@ public class CompressionInventoryPart implements IInventoryPartHandler {
 		if (toExtract > 0) {
 			SlotDefinition slotDefinition = slotDefinitions.get(slot);
 			ItemStack slotStack = parent.getSlotStack(slot);
-			toExtract = Math.min(toExtract, getLimit.applyAsInt(slotStack));
+			toExtract = Math.min(toExtract, getLimit.applyAsInt(calculatedStacks.get(slot)));
 			ItemStack result = slotDefinition.isCompressible() ? new ItemStack(slotDefinition.item(), toExtract) : ItemHandlerHelper.copyStackWithSize(slotStack, toExtract);
 
 			if (!simulate) {
@@ -312,9 +327,10 @@ public class CompressionInventoryPart implements IInventoryPartHandler {
 				} else {
 					slotStack.shrink(toExtract);
 					parent.setSlotStack(slot, slotStack);
-					calculatedStacks.put(slot, slotStack.copy());
+					setCalculatedStack(slot, slotStack.copy());
 				}
 				removeDefinitionsIfEmpty(slot);
+				refreshCalculatedSlots();
 			}
 
 			return result;
@@ -417,7 +433,7 @@ public class CompressionInventoryPart implements IInventoryPartHandler {
 			int toSet = getCountChangeLeavingSpaceBeforeMaxInt(countBeforeChange - extractCount, slotCalculated, calculatedStack);
 			calculatedStack.setCount(toSet);
 
-			calculatedStacks.put(slotCalculated, calculatedStack);
+			setCalculatedStack(slotCalculated, calculatedStack);
 
 			multiplier = getPrevSlotMultiplier(slotCalculated);
 			extractCount = countBeforeChange / multiplier - calculatedStack.getCount() / multiplier;
@@ -447,7 +463,7 @@ public class CompressionInventoryPart implements IInventoryPartHandler {
 			int countSet = calculatedStack.getCount() - extractCount;
 			countSet = getCountChangeLeavingSpaceBeforeMaxInt(countSet, slot, calculatedStack);
 			calculatedStack.setCount(countSet);
-			calculatedStacks.put(slot, calculatedStack);
+			setCalculatedStack(slot, calculatedStack);
 			slot++;
 		}
 	}
@@ -470,6 +486,9 @@ public class CompressionInventoryPart implements IInventoryPartHandler {
 			definitions = getSlotDefinitions(stack.getItem(), slot, Map.of());
 		}
 
+		if (!hasValidSlotDefinitions(definitions, slot)) {
+			return stack;
+		}
 		limit = getStackLimit(definitions.get(slot));
 
 		int currentCalculatedCount = calculatedStacks.containsKey(slot) ? calculatedStacks.get(slot).getCount() : 0;
@@ -492,7 +511,9 @@ public class CompressionInventoryPart implements IInventoryPartHandler {
 		}
 
 		if (slotDefinitions.get(slot).isCompressible()) {
-			insertIntoInternalAndCalculated(slot, inserted);
+			if (!insertIntoInternalAndCalculated(slot, inserted)) {
+				return stack;
+			}
 		} else if (inserted > 0) {
 			calculatedStacks.compute(slot, (s, st) -> {
 				if (st ==null || st.isEmpty()) {
@@ -503,6 +524,7 @@ public class CompressionInventoryPart implements IInventoryPartHandler {
 				st.grow(inserted);
 				return st;
 			});
+			lastCalculatedCounts.put(slot, calculatedStacks.get(slot).getCount());
 			ItemStack slotStack = parent.getSlotStack(slot);
 			if (slotStack.isEmpty()) {
 				ItemStack copy = stack.copy();
@@ -514,11 +536,12 @@ public class CompressionInventoryPart implements IInventoryPartHandler {
 			}
 		}
 
+		refreshCalculatedSlots();
 		return result;
 	}
 
 	private boolean canNotBeInserted(int slot, ItemStack stack) {
-		if (stack.isEmpty()) {
+		if (stack.isEmpty() || slot < slotRange.firstSlot() || slot >= slotRange.firstSlot() + slotRange.numberOfSlots()) {
 			return true;
 		}
 
@@ -530,7 +553,21 @@ public class CompressionInventoryPart implements IInventoryPartHandler {
 		return !slotDefinition.isAccessible() || slotDefinition.item() != stack.getItem();
 	}
 
-	private void insertIntoInternalAndCalculated(int slotToStartFrom, long amountToInsert) {
+	private boolean hasValidSlotDefinitions(Map<Integer, SlotDefinition> definitions, int slot) {
+		SlotDefinition definition = definitions.get(slot);
+		return definition != null && definition.isAccessible() && definitions.values().stream().noneMatch(d -> d.isAccessible() && d.prevSlotMultiplier <= 0);
+	}
+
+	private void refreshCalculatedSlots() {
+		for (int slot = slotRange.firstSlot(); slot < slotRange.firstSlot() + slotRange.numberOfSlots(); slot++) {
+			parent.getSlotTracker().removeAndSetSlotIndexes(parent, slot, calculatedStacks.getOrDefault(slot, ItemStack.EMPTY));
+		}
+		for (int slot = slotRange.firstSlot(); slot < slotRange.firstSlot() + slotRange.numberOfSlots(); slot++) {
+			parent.triggerOnChangeListeners(slot);
+		}
+	}
+
+	private boolean insertIntoInternalAndCalculated(int slotToStartFrom, long amountToInsert) {
 		Map<Integer, Integer> toUpdate = new LinkedHashMap<>();
 		Map<Integer, Integer> calculatedAdditions = new LinkedHashMap<>();
 		int totalMultiplier = 1;
@@ -558,15 +595,19 @@ public class CompressionInventoryPart implements IInventoryPartHandler {
 				toUpdate.put(slot, 0);
 			}
 
-			if (amountToSet != 0) {
+			if (amountToSet != 0 && slot < slotToStartFrom) {
 				totalMultiplier /= getPrevSlotMultiplier(slot + 1);
 			}
 			slot++;
 		}
 
+		if (amountToSet != 0) {
+			return false;
+		}
+
 		//finish calculation of calculated addition to the follow up slots even though they are not getting their internal stack changed
 		while (slot < slotRange.firstSlot() + slotRange.numberOfSlots()) {
-			if (!slotDefinitions.containsKey(slot)) {
+			if (!slotDefinitions.containsKey(slot) || !slotDefinitions.get(slot).isAccessible()) {
 				break;
 			}
 
@@ -578,13 +619,17 @@ public class CompressionInventoryPart implements IInventoryPartHandler {
 
 		updateInternalStacksWithCounts(toUpdate);
 
-		calculatedAdditions.forEach(this::addToCalculatedStack);
+		calculatedAdditions.forEach((s, countToAdd) -> {
+			addToCalculatedStack(s, countToAdd);
+			lastCalculatedCounts.put(s, calculatedStacks.get(s).getCount());
+		});
+		return true;
 	}
 
 	private void addToCalculatedStack(int slot, int countToAdd) {
 		if (!calculatedStacks.containsKey(slot) || calculatedStacks.get(slot).isEmpty()) {
 			SlotDefinition slotDefinition = slotDefinitions.get(slot);
-			calculatedStacks.put(slot, new ItemStack(slotDefinition.item(), countToAdd));
+			setCalculatedStack(slot, new ItemStack(slotDefinition.item(), countToAdd));
 			return;
 		}
 		ItemStack currentCalculated = calculatedStacks.get(slot);
@@ -610,11 +655,33 @@ public class CompressionInventoryPart implements IInventoryPartHandler {
 
 	@Override
 	public void setStackInSlot(int slot, ItemStack stack, BiConsumer<Integer, ItemStack> setStackInSlotSuper) {
-		int currentCount = calculatedStacks.containsKey(slot) ? calculatedStacks.get(slot).getCount() : 0;
-		if (currentCount < stack.getCount()) {
-			insertItem(slot, ItemHandlerHelper.copyStackWithSize(stack, stack.getCount() - currentCount), false);
-		} else if (currentCount > stack.getCount()) {
-			extractItem(slot, currentCount - stack.getCount(), false, s -> Integer.MAX_VALUE);
+		if (!stack.isEmpty() && canNotBeInserted(slot, stack)) {
+			return;
+		}
+
+		int currentCount = lastCalculatedCounts.getOrDefault(slot, 0);
+		int newCount = stack.getCount();
+		if (currentCount != (calculatedStacks.containsKey(slot) ? calculatedStacks.get(slot).getCount() : 0)) {
+			setCalculatedStack(slot, new ItemStack(slotDefinitions.get(slot).item(), currentCount));
+		}
+
+		if (currentCount < newCount) {
+			insertItem(slot, ItemHandlerHelper.copyStackWithSize(stack, newCount - currentCount), false);
+		} else if (currentCount > newCount) {
+			extractItemIgnoringLimit(slot, currentCount - newCount, false);
+		}
+	}
+
+	@Override
+	public void onContentsChanged(int slot, BiConsumer<Integer, ItemStack> setStackInSlotSuper) {
+		if (isReconcilingStacks || !slotDefinitions.containsKey(slot)) {
+			return;
+		}
+		isReconcilingStacks = true;
+		try {
+			setStackInSlot(slot, calculatedStacks.getOrDefault(slot, ItemStack.EMPTY), setStackInSlotSuper);
+		} finally {
+			isReconcilingStacks = false;
 		}
 	}
 

--- a/src/main/resources/assets/sophisticatedstorage/lang/en_us.json
+++ b/src/main/resources/assets/sophisticatedstorage/lang/en_us.json
@@ -1,4 +1,11 @@
 {
+    "item.sophisticatedstorage.barrel.tooltip.tier" : "Tier: %s",
+    "storage_tier.sophisticatedstorage.wood" : "Wood",
+    "storage_tier.sophisticatedstorage.copper" : "Copper",
+    "storage_tier.sophisticatedstorage.iron" : "Iron",
+    "storage_tier.sophisticatedstorage.gold" : "Gold",
+    "storage_tier.sophisticatedstorage.diamond" : "Diamond",
+    "storage_tier.sophisticatedstorage.netherite" : "Netherite",
     "wood_name.sophisticatedstorage.oak" : "Oak",
     "wood_name.sophisticatedstorage.spruce" : "Spruce",
     "wood_name.sophisticatedstorage.birch" : "Birch",

--- a/src/test/java/net/p3pp3rf1y/sophisticatedstorage/client/render/LimitedBarrelRendererTest.java
+++ b/src/test/java/net/p3pp3rf1y/sophisticatedstorage/client/render/LimitedBarrelRendererTest.java
@@ -1,0 +1,82 @@
+package net.p3pp3rf1y.sophisticatedstorage.client.render;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import com.mojang.math.Vector3f;
+import com.mojang.math.Vector4f;
+import net.minecraft.SharedConstants;
+import net.minecraft.client.StringSplitter;
+import net.minecraft.client.gui.Font;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.util.FormattedCharSequence;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.*;
+
+class LimitedBarrelRendererTest {
+	@BeforeAll
+	static void setup() {
+		SharedConstants.tryDetectVersion();
+		Bootstrap.bootStrap();
+	}
+
+	@AfterEach
+	void clearCache() {
+		LimitedBarrelRenderer.clearCountCache();
+	}
+
+	@Test
+	void countLabelsReuseLayoutAndInvalidateForFontChangesAndReloads() {
+		Font font = mock(Font.class);
+		StringSplitter splitter = mock(StringSplitter.class);
+		when(font.getSplitter()).thenReturn(splitter);
+		when(splitter.stringWidth(any(FormattedCharSequence.class))).thenReturn(12.5f);
+
+		LimitedBarrelRenderer.CountLabel label = LimitedBarrelRenderer.getCountLabel(font, 100000, 6);
+		assertEquals(12.5f, label.width());
+		assertSame(label, LimitedBarrelRenderer.getCountLabel(font, 100000, 6));
+		verify(splitter).stringWidth(any(FormattedCharSequence.class));
+		assertNotSame(label, LimitedBarrelRenderer.getCountLabel(font, 100000, 5));
+
+		Font changedFont = mock(Font.class);
+		when(changedFont.getSplitter()).thenReturn(splitter);
+		assertNotSame(label, LimitedBarrelRenderer.getCountLabel(changedFont, 100000, 6));
+
+		LimitedBarrelRenderer.CountLabel beforeReload = LimitedBarrelRenderer.getCountLabel(font, 100000, 6);
+		LimitedBarrelRenderer.clearCountCache();
+		assertNotSame(beforeReload, LimitedBarrelRenderer.getCountLabel(font, 100000, 6));
+	}
+
+	@ParameterizedTest
+	@ValueSource(floats = {0.25f, 0.5f, 1f})
+	void fillVerticesPreserveTransformAndSpriteWrapper(float fillLevel) {
+		PoseStack poseStack = new PoseStack();
+		poseStack.translate(0.5, 0.5, 0.5);
+		poseStack.mulPose(Vector3f.YP.rotationDegrees(90));
+		poseStack.scale(3 / 80f, fillLevel * 68 / 80f, 1);
+		VertexConsumer consumer = mock(VertexConsumer.class, CALLS_REAL_METHODS);
+		VertexConsumer underlying = mock(VertexConsumer.class);
+		when(consumer.vertex(anyDouble(), anyDouble(), anyDouble())).thenReturn(underlying);
+		when(consumer.color(anyInt(), anyInt(), anyInt(), anyInt())).thenReturn(underlying);
+		when(consumer.uv(anyFloat(), anyFloat())).thenReturn(underlying);
+		when(consumer.normal(anyFloat(), anyFloat(), anyFloat())).thenReturn(underlying);
+		Vector3f normal = new Vector3f(0, 1, 0);
+		normal.transform(poseStack.last().normal());
+
+		LimitedBarrelRenderer.renderFillVertex(consumer, poseStack.last(), new Vector4f(), normal, 0, 1, 3 / 128f, 0, 0.5f, 7, 9);
+
+		verify(consumer).uv(3 / 128f, 0);
+		verify(consumer).normal(normal.x(), normal.y(), normal.z());
+		verify(consumer).overlayCoords(7);
+		verify(consumer).uv2(9);
+		verify(consumer).endVertex();
+		verifyNoInteractions(underlying);
+	}
+}

--- a/src/test/java/net/p3pp3rf1y/sophisticatedstorage/client/render/SporeBlossomDisplayModelTest.java
+++ b/src/test/java/net/p3pp3rf1y/sophisticatedstorage/client/render/SporeBlossomDisplayModelTest.java
@@ -1,0 +1,120 @@
+package net.p3pp3rf1y.sophisticatedstorage.client.render;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.math.Matrix4f;
+import com.mojang.math.Vector3f;
+import com.mojang.math.Vector4f;
+import net.minecraft.SharedConstants;
+import net.minecraft.client.renderer.block.model.ItemTransform;
+import net.minecraft.client.renderer.block.model.ItemTransforms;
+import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraftforge.client.ForgeHooksClient;
+import net.minecraftforge.common.model.TransformationHelper;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+class SporeBlossomDisplayModelTest {
+	@BeforeAll
+	static void setup() {
+		SharedConstants.tryDetectVersion();
+		Bootstrap.bootStrap();
+	}
+
+	@Test
+	void vanillaAttachmentIsFlushAndAllPetalsProjectOutward() throws Exception {
+		BakedModel model = SporeBlossomDisplayModel.wrap(new ItemStack(Items.SPORE_BLOSSOM), getOriginalModel());
+		Matrix4f transform = TransformationHelper.toTransformation(model.getTransforms().fixed).getMatrix();
+		try (InputStream stream = getClass().getResourceAsStream("/assets/minecraft/models/block/spore_blossom.json")) {
+			assertNotNull(stream, "Validate against the actual Minecraft model geometry");
+			JsonArray elements = JsonParser.parseReader(new InputStreamReader(stream, StandardCharsets.UTF_8))
+					.getAsJsonObject().getAsJsonArray("elements");
+			for (int elementIndex = 0; elementIndex < elements.size(); elementIndex++) {
+				JsonObject element = elements.get(elementIndex).getAsJsonObject();
+				JsonArray from = element.getAsJsonArray("from");
+				JsonArray to = element.getAsJsonArray("to");
+				for (int corner = 0; corner < 8; corner++) {
+					Vector3f vertex = new Vector3f(
+							((corner & 1) == 0 ? from : to).get(0).getAsFloat(),
+							((corner & 2) == 0 ? from : to).get(1).getAsFloat(),
+							((corner & 4) == 0 ? from : to).get(2).getAsFloat());
+					if (element.has("rotation")) {
+						JsonObject rotation = element.getAsJsonObject("rotation");
+						JsonArray xyz = rotation.getAsJsonArray("origin");
+						Vector3f origin = new Vector3f(xyz.get(0).getAsFloat(), xyz.get(1).getAsFloat(), xyz.get(2).getAsFloat());
+						Vector3f axis = rotation.get("axis").getAsString().equals("x") ? Vector3f.XP : Vector3f.ZP;
+						vertex.sub(origin);
+						vertex.transform(axis.rotationDegrees(rotation.get("angle").getAsFloat()));
+						vertex.add(origin);
+					}
+					Vector4f displayed = new Vector4f(vertex.x() / 16 - 0.5F,
+							vertex.y() / 16 - 0.5F, vertex.z() / 16 - 0.5F, 1);
+					displayed.transform(transform);
+					for (float slotScale : new float[] {1.0F, 0.5F}) {
+						double distanceOutsidePanel = SporeBlossomDisplayModel.FACE_CLEARANCE - displayed.z() * slotScale;
+						if (elementIndex == 0) {
+							assertEquals(SporeBlossomDisplayModel.FACE_CLEARANCE, distanceOutsidePanel, 1e-6,
+									"The attachment plane must sit flush against the front");
+						} else {
+							assertTrue(distanceOutsidePanel > SporeBlossomDisplayModel.FACE_CLEARANCE,
+									"Petals must extend away from the panel, not into the barrel");
+						}
+					}
+				}
+			}
+		}
+	}
+
+	@Test
+	void forgeDynamicRenderingUsesTheSameTransformAsBakedQuads() {
+		BakedModel model = SporeBlossomDisplayModel.wrap(new ItemStack(Items.SPORE_BLOSSOM), getOriginalModel());
+		PoseStack dynamic = new PoseStack();
+		assertSame(model, ForgeHooksClient.handleCameraTransforms(dynamic, model, ItemTransforms.TransformType.FIXED, false));
+		Matrix4f baked = TransformationHelper.toTransformation(model.getTransforms().fixed).getMatrix();
+		for (Vector4f point : new Vector4f[] {new Vector4f(0, 0, 0, 1), new Vector4f(0.3F, 0.49F, -0.4F, 1)}) {
+			Vector4f expected = new Vector4f(point.x(), point.y(), point.z(), point.w());
+			expected.transform(baked);
+			point.transform(dynamic.last().pose());
+			assertEquals(expected.x(), point.x(), 1e-6);
+			assertEquals(expected.y(), point.y(), 1e-6);
+			assertEquals(expected.z(), point.z(), 1e-6);
+		}
+	}
+
+	@Test
+	void leavesOtherItemsAndTheSharedModelUnchanged() {
+		BakedModel original = getOriginalModel();
+		ItemTransform fixed = original.getTransforms().fixed;
+		assertSame(original, SporeBlossomDisplayModel.wrap(new ItemStack(Items.STONE), original));
+		BakedModel blossom = SporeBlossomDisplayModel.wrap(new ItemStack(Items.SPORE_BLOSSOM), original);
+		assertNotSame(original, blossom);
+		assertSame(fixed, original.getTransforms().fixed);
+		assertEquals(0, fixed.rotation.x());
+		assertSame(original.getTransforms().gui, blossom.getTransforms().gui);
+		assertSame(blossom, SporeBlossomDisplayModel.wrap(new ItemStack(Items.SPORE_BLOSSOM), blossom));
+	}
+
+	private BakedModel getOriginalModel() {
+		BakedModel model = mock(BakedModel.class);
+		ItemTransform none = ItemTransform.NO_TRANSFORM;
+		ItemTransform fixed = new ItemTransform(new Vector3f(), new Vector3f(), new Vector3f(0.5F, 0.5F, 0.5F));
+		when(model.getTransforms()).thenReturn(new ItemTransforms(none, none, none, none, none, none, none, fixed));
+		return model;
+	}
+}

--- a/src/test/java/net/p3pp3rf1y/sophisticatedstorage/compat/compressium/CompressiumDisplayModelTest.java
+++ b/src/test/java/net/p3pp3rf1y/sophisticatedstorage/compat/compressium/CompressiumDisplayModelTest.java
@@ -1,0 +1,130 @@
+package net.p3pp3rf1y.sophisticatedstorage.compat.compressium;
+
+import com.mojang.blaze3d.platform.NativeImage;
+import net.minecraft.SharedConstants;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.block.model.BakedQuad;
+import net.minecraft.client.renderer.block.model.ItemTransforms;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.core.Direction;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.server.packs.resources.Resource;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraftforge.client.model.data.EmptyModelData;
+import net.minecraftforge.fml.ModList;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.GameData;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.io.ByteArrayInputStream;
+import java.io.FileNotFoundException;
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.*;
+
+class CompressiumDisplayModelTest {
+	private static Item compressedStone;
+
+	@BeforeAll
+	static void setup() {
+		SharedConstants.tryDetectVersion();
+		Bootstrap.bootStrap();
+		GameData.unfreezeData();
+		compressedStone = new BlockItem(Blocks.STONE, new Item.Properties()).setRegistryName("compressium", "stone_1");
+		ForgeRegistries.ITEMS.register(compressedStone);
+	}
+
+	@BeforeEach
+	void clearCache() {
+		CompressiumDisplayModel.clearCache();
+	}
+
+	@Test
+	void missingModLeavesEvenMatchingItemsUntouched() {
+		try (MockedStatic<ModList> mods = mockStatic(ModList.class)) {
+			mods.when(ModList::get).thenReturn(mock(ModList.class));
+			BakedModel original = mock(BakedModel.class);
+			assertSame(original, CompressiumDisplayModel.wrap(new ItemStack(compressedStone), original));
+			verifyNoInteractions(original);
+		}
+	}
+
+	@Test
+	void loadedModLeavesOtherNamespacesUntouched() {
+		try (MockedStatic<ModList> mods = mockStatic(ModList.class)) {
+			ModList list = mock(ModList.class);
+			when(list.isLoaded("compressium")).thenReturn(true);
+			mods.when(ModList::get).thenReturn(list);
+			BakedModel original = mock(BakedModel.class);
+			assertSame(original, CompressiumDisplayModel.wrap(new ItemStack(Items.STONE), original));
+			verifyNoInteractions(original);
+		}
+	}
+
+	@Test
+	void missingOverlayFallsBackToOriginalModel() throws Exception {
+		try (MockedStatic<ModList> mods = mockStatic(ModList.class); MockedStatic<Minecraft> client = mockStatic(Minecraft.class)) {
+			ResourceManager resources = setupResources(mods, client);
+			when(resources.getResource(any(ResourceLocation.class))).thenThrow(new FileNotFoundException());
+			BakedModel original = mock(BakedModel.class);
+			assertSame(original, CompressiumDisplayModel.wrap(new ItemStack(compressedStone), original));
+		}
+	}
+
+	@Test
+	void bakedAndDynamicRenderingUseOverlayAndReloadDropsCachedGeometry() throws Exception {
+		try (MockedStatic<ModList> mods = mockStatic(ModList.class); MockedStatic<Minecraft> client = mockStatic(Minecraft.class);
+				NativeImage image = new NativeImage(2, 2, true)) {
+			ResourceManager resources = setupResources(mods, client);
+			image.setPixelRGBA(0, 0, 0xFF000000);
+			byte[] png = image.asByteArray();
+			Resource resource = mock(Resource.class);
+			when(resource.getInputStream()).thenAnswer(i -> new ByteArrayInputStream(png));
+			when(resources.getResource(new ResourceLocation("compressium", "textures/block/layer_1.png"))).thenReturn(resource);
+			BakedModel original = mock(BakedModel.class);
+			when(original.getParticleIcon()).thenReturn(mock(TextureAtlasSprite.class));
+			when(original.getTransforms()).thenReturn(ItemTransforms.NO_TRANSFORMS);
+			ItemStack stack = new ItemStack(compressedStone);
+			BakedModel model = CompressiumDisplayModel.wrap(stack, original);
+			assertNotSame(original, model);
+			assertFalse(model.isCustomRenderer());
+			for (Direction side : Direction.values()) {
+				List<BakedQuad> baked = model.getQuads(null, side, new Random());
+				List<BakedQuad> dynamic = model.getQuads(null, side, new Random(), EmptyModelData.INSTANCE);
+				assertEquals(4, baked.size());
+				assertSame(baked, dynamic);
+				assertEquals(0xFF000000, baked.get(0).getVertices()[3]);
+				assertEquals(0xFFFFFFFF, baked.get(1).getVertices()[3]);
+			}
+			assertSame(model, CompressiumDisplayModel.wrap(stack, original));
+			CompressiumDisplayModel.clearCache();
+			assertNotSame(model, CompressiumDisplayModel.wrap(stack, original));
+		}
+	}
+
+	private ResourceManager setupResources(MockedStatic<ModList> mods, MockedStatic<Minecraft> client) {
+		ModList list = mock(ModList.class);
+		when(list.isLoaded("compressium")).thenReturn(true);
+		mods.when(ModList::get).thenReturn(list);
+		Minecraft minecraft = mock(Minecraft.class);
+		client.when(Minecraft::getInstance).thenReturn(minecraft);
+		ResourceManager resources = mock(ResourceManager.class);
+		when(minecraft.getResourceManager()).thenReturn(resources);
+		return resources;
+	}
+}

--- a/src/test/java/net/p3pp3rf1y/sophisticatedstorage/item/StorageContentsWrapperTest.java
+++ b/src/test/java/net/p3pp3rf1y/sophisticatedstorage/item/StorageContentsWrapperTest.java
@@ -1,0 +1,294 @@
+package net.p3pp3rf1y.sophisticatedstorage.item;
+
+import com.electronwill.nightconfig.core.CommentedConfig;
+import net.minecraft.SharedConstants;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.StringTag;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraftforge.eventbus.ListenerList;
+import net.minecraftforge.eventbus.api.EventListenerHelper;
+import net.minecraftforge.fml.util.ObfuscationReflectionHelper;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.GameData;
+import net.p3pp3rf1y.sophisticatedcore.inventory.InventoryHandler;
+import net.p3pp3rf1y.sophisticatedcore.inventory.InventoryPartRegistry;
+import net.p3pp3rf1y.sophisticatedcore.upgrades.IUpgradeWrapper;
+import net.p3pp3rf1y.sophisticatedcore.upgrades.stack.StackUpgradeItem;
+import net.p3pp3rf1y.sophisticatedcore.util.RecipeHelper;
+import net.p3pp3rf1y.sophisticatedstorage.Config;
+import net.p3pp3rf1y.sophisticatedstorage.block.IStorageBlock;
+import net.p3pp3rf1y.sophisticatedstorage.upgrades.compression.CompressionInventoryPart;
+import net.p3pp3rf1y.sophisticatedstorage.upgrades.compression.CompressionUpgradeItem;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+class StorageContentsWrapperTest {
+	private static StackUpgradeItem stackUpgrade;
+	private static CompressionUpgradeItem compressionUpgrade;
+	private MockedStatic<RecipeHelper> recipes;
+	private Item[] denominations;
+
+	@BeforeAll
+	static void setup() throws Exception {
+		SharedConstants.tryDetectVersion();
+		Bootstrap.bootStrap();
+		try (MockedStatic<ObfuscationReflectionHelper> reflection = mockStatic(ObfuscationReflectionHelper.class)) {
+			Field field = ItemStack.class.getDeclaredField("capNBT");
+			field.setAccessible(true);
+			reflection.when(() -> ObfuscationReflectionHelper.findField(ItemStack.class, "capNBT")).thenReturn(field);
+			Class.forName("net.p3pp3rf1y.sophisticatedcore.inventory.ItemStackKey");
+		}
+		GameData.unfreezeData();
+		Config.SERVER_SPEC.setConfig(CommentedConfig.inMemory());
+		InventoryPartRegistry.registerFactory(CompressionInventoryPart.NAME, CompressionInventoryPart::new);
+		stackUpgrade = new StackUpgradeItem(4, CreativeModeTab.TAB_MISC, Config.SERVER.maxUpgradesPerStorage);
+		stackUpgrade.setRegistryName("sophisticatedstorage_test", "stack_upgrade");
+		ForgeRegistries.ITEMS.register(stackUpgrade);
+		compressionUpgrade = new CompressionUpgradeItem(CreativeModeTab.TAB_MISC);
+		compressionUpgrade.setRegistryName("sophisticatedstorage_test", "compression_upgrade");
+		ForgeRegistries.ITEMS.register(compressionUpgrade);
+		try (MockedStatic<EventListenerHelper> events = mockStatic(EventListenerHelper.class)) {
+			events.when(() -> EventListenerHelper.getListenerList(any(Class.class))).thenReturn(new ListenerList());
+			Class.forName("net.p3pp3rf1y.sophisticatedstorage.settings.StorageSettingsHandler");
+		}
+	}
+
+	@BeforeEach
+	void setUpRecipes() throws Exception {
+		denominations = new Item[] {Items.DIAMOND_BLOCK, Items.IRON_BLOCK, Items.IRON_INGOT, Items.IRON_NUGGET};
+		recipes = Mockito.mockStatic(RecipeHelper.class);
+		recipes.when(() -> RecipeHelper.getItemCompactingShapes(any(Item.class))).thenReturn(Set.of(RecipeHelper.CompactingShape.NONE));
+		recipes.when(() -> RecipeHelper.getUncompactingResult(any(Item.class))).thenReturn(RecipeHelper.UncompactingResult.EMPTY);
+		Constructor<RecipeHelper.CompactingResult> resultConstructor = RecipeHelper.CompactingResult.class.getDeclaredConstructor(ItemStack.class, List.class);
+		resultConstructor.setAccessible(true);
+		for (int i = 1; i < denominations.length; i++) {
+			Item lower = denominations[i];
+			Item upper = denominations[i - 1];
+			RecipeHelper.CompactingShape shape = RecipeHelper.CompactingShape.THREE_BY_THREE_UNCRAFTABLE;
+			RecipeHelper.CompactingResult result = resultConstructor.newInstance(new ItemStack(upper), List.of());
+			recipes.when(() -> RecipeHelper.getItemCompactingShapes(lower)).thenReturn(Set.of(shape));
+			recipes.when(() -> RecipeHelper.getCompactingResult(lower, shape)).thenReturn(result);
+			recipes.when(() -> RecipeHelper.getUncompactingResult(upper)).thenReturn(new RecipeHelper.UncompactingResult(lower, shape));
+		}
+	}
+
+	@AfterEach
+	void closeRecipes() {
+		recipes.close();
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = {1, 2, 3, 4})
+	void showsEveryCalculatedDenominationInSlotOrder(int slots) {
+		Item[] items = Arrays.copyOfRange(denominations, 4 - slots, 4);
+		CompoundTag saved = getInventoryTag(slots, true, new ItemStack(items[0], 129));
+		CompoundTag before = saved.copy();
+
+		List<ItemStack> result = new StorageContentsWrapper(getBarrel(slots), saved).getContents();
+
+		assertEquals(slots, result.size());
+		int count = 129;
+		for (int i = 0; i < slots; i++) {
+			assertSame(items[i], result.get(i).getItem());
+			assertEquals(count, result.get(i).getCount());
+			count *= 9;
+		}
+		assertEquals(before, saved, "Preview must not modify synchronized contents");
+	}
+
+	@Test
+	void calculatesRemaindersWithoutChangingSavedDataOrEarlierPreviews() {
+		CompoundTag saved = getInventoryTag(3, true, new ItemStack(Items.IRON_BLOCK),
+				new ItemStack(Items.IRON_INGOT, 20), new ItemStack(Items.IRON_NUGGET, 40));
+		CompoundTag before = saved.copy();
+
+		List<ItemStack> first = new StorageContentsWrapper(getBarrel(3), saved).getContents();
+		assertEquals(List.of(3, 33, 301), first.stream().map(ItemStack::getCount).toList());
+		first.get(0).setCount(999);
+		List<ItemStack> second = new StorageContentsWrapper(getBarrel(3), saved).getContents();
+		assertEquals(List.of(3, 33, 301), second.stream().map(ItemStack::getCount).toList());
+		assertEquals(before, saved);
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = {1, 2, 3, 4})
+	void directSlotMutationReconcilesInternalCompressionCounts(int slots) {
+		Item highest = denominations[4 - slots];
+		StorageContentsWrapper preview = new StorageContentsWrapper(getBarrel(slots), getInventoryTag(slots, true, new ItemStack(highest, 2)));
+		InventoryHandler handler = preview.getInventoryHandler();
+		int lastSlot = slots - 1;
+		int originalCount = handler.getStackInSlot(lastSlot).getCount();
+		ItemStack removed = handler.getStackInSlot(lastSlot).split(1);
+
+		handler.onContentsChanged(lastSlot);
+		assertEquals(originalCount - 1, handler.getStackInSlot(lastSlot).getCount());
+
+		handler.onContentsChanged(lastSlot);
+		assertEquals(originalCount - 1, handler.getStackInSlot(lastSlot).getCount());
+
+		ItemStack remainder = handler.extractItemIgnoringLimit(lastSlot, Integer.MAX_VALUE, false);
+		assertEquals(originalCount, removed.getCount() + remainder.getCount());
+		for (int slot = 0; slot < slots; slot++) {
+			assertTrue(handler.getSlotStack(slot).isEmpty());
+		}
+	}
+
+	@Test
+	void reflectsNewContentsAfterSyncAndKeepsOtherBarrelsIndependent() {
+		CompoundTag first = getInventoryTag(2, true, new ItemStack(Items.IRON_INGOT, 2));
+		CompoundTag second = getInventoryTag(2, true, new ItemStack(Items.IRON_INGOT, 7));
+		assertEquals(List.of(2, 18), getCounts(first, 2));
+		assertEquals(List.of(7, 63), getCounts(second, 2));
+		assertEquals(List.of(2, 18), getCounts(first, 2));
+	}
+
+	@Test
+	void ordinarySlotsKeepTheirItemsNbtAndFullCounts() {
+		ItemStack named = new ItemStack(Items.DIAMOND, 257);
+		named.getOrCreateTag().putString("testMarker", "preserved");
+		CompoundTag saved = getInventoryTag(4, false, new ItemStack(Items.DIRT), ItemStack.EMPTY,
+				named, new ItemStack(Items.DIRT, 3));
+		CompoundTag before = saved.copy();
+		List<ItemStack> result = new StorageContentsWrapper(getBarrel(4), saved).getContents();
+		assertEquals(3, result.size());
+		assertSame(Items.DIRT, result.get(0).getItem());
+		assertSame(Items.DIAMOND, result.get(1).getItem());
+		assertEquals(257, result.get(1).getCount());
+		assertEquals("preserved", result.get(1).getTag().getString("testMarker"));
+		assertSame(Items.DIRT, result.get(2).getItem(), "Separate slots should not be merged");
+		assertEquals(before, saved);
+	}
+
+	@Test
+	void emptyBarrelsRemainEmptyAndUnpackedItemsAreNotHandled() {
+		assertTrue(new StorageContentsWrapper(getBarrel(4), getInventoryTag(4, true)).getContents().isEmpty());
+		assertTrue(StorageContentsWrapper.fromStack(new ItemStack(Items.BARREL)).isEmpty());
+		assertTrue(StorageContentsWrapper.fromStack(ItemStack.EMPTY).isEmpty());
+	}
+
+	@Test
+	void restoresAllSavedUpgradeSlotsAndTheBaseTimesUpgradeMultiplier() {
+		CompoundTag saved = getInventoryTag(27, false, new ItemStack(Items.DIAMOND, 257));
+		addUpgrades(saved);
+		CompoundTag before = saved.copy();
+		IStorageBlock block = getBarrel(27);
+		when(block.getNumberOfUpgradeSlots()).thenReturn(2);
+		when(block.getBaseStackSizeMultiplier()).thenReturn(8);
+
+		StorageContentsWrapper preview = new StorageContentsWrapper(block, saved);
+		Map<Integer, IUpgradeWrapper> upgrades = preview.getUpgradeHandler().getSlotWrappers();
+		assertEquals(Set.of(1, 3), upgrades.keySet());
+		assertSame(compressionUpgrade, upgrades.get(1).getUpgradeStack().getItem());
+		assertSame(stackUpgrade, upgrades.get(3).getUpgradeStack().getItem());
+		assertEquals("saved-upgrade", upgrades.get(3).getUpgradeStack().getTag().getString("testMarker"));
+		assertEquals(32, preview.getInventoryHandler().getStackSizeMultiplier());
+		assertEquals(before, saved);
+		upgrades.get(3).getUpgradeStack().getOrCreateTag().putString("testMarker", "changed-preview");
+		assertEquals(before, saved);
+	}
+
+	@Test
+	void upgradeOnlyBarrelsRetainIconsWhenThereIsNoInventoryTag() {
+		CompoundTag saved = getInventoryTag(27, false);
+		saved.getCompound("contents").remove("inventory");
+		addUpgrades(saved);
+		StorageContentsWrapper preview = new StorageContentsWrapper(getBarrel(27), saved);
+		assertTrue(preview.getContents().isEmpty());
+		assertEquals(2, preview.getUpgradeHandler().getSlotWrappers().size());
+	}
+
+	@Test
+	void compressedContentsAndUpgradesComeFromTheSameDetachedPreview() {
+		CompoundTag saved = getInventoryTag(3, true, new ItemStack(Items.IRON_BLOCK, 129));
+		addUpgrades(saved);
+		CompoundTag before = saved.copy();
+		StorageContentsWrapper preview = new StorageContentsWrapper(getBarrel(3), saved);
+		assertEquals(List.of(129, 1161, 10449), preview.getContents().stream().map(ItemStack::getCount).toList());
+		assertEquals(2, preview.getUpgradeHandler().getSlotWrappers().size());
+		assertEquals(2048, preview.getInventoryHandler().getStackSizeMultiplier());
+		assertEquals(before, saved);
+	}
+
+	private void addUpgrades(CompoundTag saved) {
+		CompoundTag upgrades = new CompoundTag();
+		upgrades.putInt("Size", 4);
+		ListTag items = new ListTag();
+		CompoundTag compression = new ItemStack(compressionUpgrade).save(new CompoundTag());
+		compression.putInt("Slot", 1);
+		items.add(compression);
+		ItemStack stack = new ItemStack(stackUpgrade);
+		stack.getOrCreateTag().putString("testMarker", "saved-upgrade");
+		CompoundTag stacking = stack.save(new CompoundTag());
+		stacking.putInt("Slot", 3);
+		items.add(stacking);
+		upgrades.put("Items", items);
+		saved.getCompound("contents").put("upgradeInventory", upgrades);
+		saved.putInt("numberOfUpgradeSlots", 4);
+	}
+
+	private List<Integer> getCounts(CompoundTag saved, int slots) {
+		return new StorageContentsWrapper(getBarrel(slots), saved).getContents().stream().map(ItemStack::getCount).toList();
+	}
+
+	private IStorageBlock getBarrel(int slots) {
+		IStorageBlock block = mock(IStorageBlock.class);
+		when(block.getNumberOfInventorySlots()).thenReturn(slots);
+		when(block.getNumberOfUpgradeSlots()).thenReturn(0);
+		when(block.getBaseStackSizeMultiplier()).thenReturn(512);
+		return block;
+	}
+
+	private CompoundTag getInventoryTag(int slots, boolean compression, ItemStack... stacks) {
+		CompoundTag inventory = new CompoundTag();
+		ListTag items = new ListTag();
+		for (int i = 0; i < stacks.length; i++) {
+			if (stacks[i].isEmpty()) {
+				continue;
+			}
+			CompoundTag item = stacks[i].save(new CompoundTag());
+			item.putInt("Slot", i);
+			item.putInt("realCount", stacks[i].getCount());
+			items.add(item);
+		}
+		inventory.putInt("Size", slots);
+		inventory.put("Items", items);
+		CompoundTag contents = new CompoundTag();
+		contents.put("inventory", inventory);
+		if (compression) {
+			CompoundTag partitioner = new CompoundTag();
+			partitioner.putIntArray("baseIndexes", new int[] {0});
+			ListTag parts = new ListTag();
+			parts.add(StringTag.valueOf(CompressionInventoryPart.NAME));
+			partitioner.put("inventoryPartNames", parts);
+			contents.put("partitioner", partitioner);
+		}
+		CompoundTag wrapper = new CompoundTag();
+		wrapper.putInt("numberOfInventorySlots", slots);
+		wrapper.putInt("numberOfUpgradeSlots", 0);
+		wrapper.put("contents", contents);
+		return wrapper;
+	}
+}

--- a/src/test/java/net/p3pp3rf1y/sophisticatedstorage/upgrades/compression/CompressionInventoryPartTest.java
+++ b/src/test/java/net/p3pp3rf1y/sophisticatedstorage/upgrades/compression/CompressionInventoryPartTest.java
@@ -7,6 +7,7 @@ import net.minecraft.server.Bootstrap;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.p3pp3rf1y.sophisticatedcore.inventory.ISlotTracker;
 import net.p3pp3rf1y.sophisticatedcore.inventory.InventoryHandler;
 import net.p3pp3rf1y.sophisticatedcore.inventory.InventoryPartitioner;
 import net.p3pp3rf1y.sophisticatedcore.settings.memory.MemorySettingsCategory;
@@ -21,11 +22,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
+import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -37,6 +40,7 @@ import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.AssertionFailureBuilder.assertionFailure;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.*;
 
 public class CompressionInventoryPartTest {
@@ -78,6 +82,7 @@ public class CompressionInventoryPartTest {
 
 	private InventoryHandler getFilledInventoryHandler(Map<Integer, ItemStack> slotStacks, int baseSlotLimit) {
 		InventoryHandler inventoryHandler = Mockito.mock(InventoryHandler.class);
+		when(inventoryHandler.getSlotTracker()).thenReturn(new ISlotTracker.Noop());
 		when(inventoryHandler.getBaseStackLimit(any(ItemStack.class))).thenAnswer(i -> {
 			ItemStack stack = i.getArgument(0);
 			int limit = MathHelper.intMaxCappedMultiply(stack.getMaxStackSize(), (baseSlotLimit / 64));
@@ -108,6 +113,110 @@ public class CompressionInventoryPartTest {
 		MemorySettingsCategory memorySettingsCategory = Mockito.spy(new MemorySettingsCategory(() -> invHandler, new CompoundTag(), compoundTag -> {}));
 		when(memorySettingsCategory.getSlotFilterStack(anyInt(), anyBoolean())).thenAnswer(i -> Optional.ofNullable(slotFilterStacks.get((int) i.getArgument(0))));
 		return memorySettingsCategory;
+	}
+
+	@Test
+	void missingSlotDefinitionRejectsInsertionWithoutChangingContents() throws Exception {
+		Map<Integer, ItemStack> stacks = Map.of(0, new ItemStack(Items.IRON_BLOCK), 1, ItemStack.EMPTY, 2, ItemStack.EMPTY);
+		InventoryHandler handler = getFilledInventoryHandler(stacks, 64);
+		CompressionInventoryPart part = initCompressionInventoryPart(stacks, handler, 0);
+		Field definitions = CompressionInventoryPart.class.getDeclaredField("slotDefinitions");
+		definitions.setAccessible(true);
+		((Map<?, ?>) definitions.get(part)).remove(1);
+		clearInvocations(handler);
+		ItemStack inserted = new ItemStack(Items.IRON_INGOT, 10);
+		assertSame(inserted, part.insertItem(1, inserted, true, null));
+		assertSame(inserted, part.insertItem(1, inserted, false, null));
+		verify(handler, never()).setSlotStack(anyInt(), any(ItemStack.class));
+		assertEquals(1, handler.getSlotStack(0).getCount());
+	}
+
+	@Test
+	void mixedCompactingShapesUseEachSlotsDenominationForItsLimit() {
+		recipeHelperMock.when(() -> RecipeHelper.getItemCompactingShapes(Items.IRON_NUGGET)).thenReturn(Set.of(RecipeHelper.CompactingShape.TWO_BY_TWO_UNCRAFTABLE));
+		recipeHelperMock.when(() -> RecipeHelper.getCompactingResult(Items.IRON_NUGGET, RecipeHelper.CompactingShape.TWO_BY_TWO_UNCRAFTABLE)).thenReturn(AccessHelper.initCompactingResult(new ItemStack(Items.IRON_INGOT), List.of()));
+		recipeHelperMock.when(() -> RecipeHelper.getUncompactingResult(Items.IRON_INGOT)).thenReturn(new RecipeHelper.UncompactingResult(Items.IRON_NUGGET, RecipeHelper.CompactingShape.TWO_BY_TWO_UNCRAFTABLE));
+		try {
+			Map<Integer, ItemStack> stacks = Map.of(0, new ItemStack(Items.IRON_BLOCK), 1, ItemStack.EMPTY, 2, ItemStack.EMPTY);
+			InventoryHandler handler = getFilledInventoryHandler(stacks, 64);
+			CompressionInventoryPart part = initCompressionInventoryPart(stacks, handler, 0);
+			assertEquals(64, part.getSlotLimit(0));
+			assertEquals(640, part.getSlotLimit(1));
+			assertEquals(2624, part.getSlotLimit(2));
+			assertEquals(36, part.getStackInSlot(2, handler::getSlotStack).getCount());
+			ItemStack remainder = part.insertItem(2, new ItemStack(Items.IRON_NUGGET, 3000), false, null);
+			assertEquals(412, remainder.getCount());
+			assertEquals(2624, part.getStackInSlot(2, handler::getSlotStack).getCount());
+		} finally {
+			recipeHelperMock.when(() -> RecipeHelper.getItemCompactingShapes(Items.IRON_NUGGET)).thenReturn(Set.of(RecipeHelper.CompactingShape.THREE_BY_THREE_UNCRAFTABLE));
+			recipeHelperMock.when(() -> RecipeHelper.getUncompactingResult(Items.IRON_INGOT)).thenReturn(new RecipeHelper.UncompactingResult(Items.IRON_NUGGET, RecipeHelper.CompactingShape.THREE_BY_THREE_UNCRAFTABLE));
+		}
+	}
+
+	@Test
+	void extractionReturnsOnlyAvailableItemsWhenRequestExceedsContents() {
+		Map<Integer, ItemStack> stacks = Map.of(0, new ItemStack(Items.IRON_BLOCK, 2), 1, ItemStack.EMPTY, 2, ItemStack.EMPTY);
+		InventoryHandler handler = getFilledInventoryHandler(stacks, 64);
+		CompressionInventoryPart part = initCompressionInventoryPart(stacks, handler, 0);
+		assertEquals(162, part.extractItem(2, 200, true).getCount());
+		assertEquals(2, handler.getSlotStack(0).getCount());
+		assertEquals(162, part.extractItem(2, 200, false).getCount());
+		assertEquals(0, part.extractItem(2, 200, false).getCount());
+		assertEquals(0, handler.getSlotStack(0).getCount());
+		assertEquals(0, handler.getSlotStack(1).getCount());
+		assertEquals(0, handler.getSlotStack(2).getCount());
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = {1, 2})
+	void extractingCraftingIngredientsAndReturningCompressedOutputPreservesContents(int ingredientSlot) {
+		Map<Integer, ItemStack> stacks = Map.of(0, new ItemStack(Items.IRON_BLOCK, 20), 1, ItemStack.EMPTY, 2, ItemStack.EMPTY);
+		InventoryHandler handler = getFilledInventoryHandler(stacks, 64);
+		CompressionInventoryPart part = initCompressionInventoryPart(stacks, handler, 0);
+		Item ingredient = ingredientSlot == 1 ? Items.IRON_INGOT : Items.IRON_NUGGET;
+		Item result = ingredientSlot == 1 ? Items.IRON_BLOCK : Items.IRON_INGOT;
+		for (int craft = 0; craft < 10; craft++) {
+			ItemStack simulated = part.extractItem(ingredientSlot, 81, true);
+			assertStackEquals(new ItemStack(ingredient, 81), simulated, "Simulated ingredient extraction");
+			assertEquals(1620, handler.getSlotStack(0).getCount() * 81 + handler.getSlotStack(1).getCount() * 9 + handler.getSlotStack(2).getCount());
+			assertEquals(0, part.extractItem(ingredientSlot, 0, false).getCount());
+			assertEquals(0, part.extractItem(ingredientSlot, -1, false).getCount());
+			ItemStack extracted = part.extractItem(ingredientSlot, 81, false);
+			assertStackEquals(simulated, extracted, "Actual ingredient extraction");
+			assertEquals(0, part.insertItem(ingredientSlot - 1, new ItemStack(result, 9), false, null).getCount());
+			assertEquals(1620, handler.getSlotStack(0).getCount() * 81 + handler.getSlotStack(1).getCount() * 9 + handler.getSlotStack(2).getCount());
+			assertEquals(1620, part.getStackInSlot(2, handler::getSlotStack).getCount());
+		}
+	}
+
+	@Test
+	void largeExtractionPreservesSimulationAndStoredQuantity() {
+		Map<Integer, ItemStack> stacks = Map.of(0, new ItemStack(Items.IRON_BLOCK, 20), 1, ItemStack.EMPTY, 2, ItemStack.EMPTY);
+		InventoryHandler handler = getFilledInventoryHandler(stacks, 64);
+		CompressionInventoryPart part = initCompressionInventoryPart(stacks, handler, 0);
+		assertEquals(800, part.extractItem(2, 800, true).getCount());
+		assertEquals(800, part.extractItemIgnoringLimit(2, 800, true).getCount());
+		assertEquals(1620, part.getStackInSlot(2, handler::getSlotStack).getCount());
+		assertEquals(800, part.extractItem(2, 800, false).getCount());
+		assertEquals(820, part.getStackInSlot(2, handler::getSlotStack).getCount());
+		assertEquals(820, handler.getSlotStack(0).getCount() * 81 + handler.getSlotStack(1).getCount() * 9 + handler.getSlotStack(2).getCount());
+	}
+
+	@Test
+	void calculatedSlotsNotifyTrackersAfterInsertionAndAfterBecomingEmpty() {
+		Map<Integer, ItemStack> stacks = Map.of(0, new ItemStack(Items.IRON_BLOCK), 1, ItemStack.EMPTY, 2, ItemStack.EMPTY, 3, ItemStack.EMPTY);
+		InventoryHandler handler = getFilledInventoryHandler(stacks, 64);
+		CompressionInventoryPart part = initCompressionInventoryPart(stacks, handler, 0);
+		ISlotTracker tracker = mock(ISlotTracker.class);
+		when(handler.getSlotTracker()).thenReturn(tracker);
+		part.insertItem(1, new ItemStack(Items.IRON_INGOT), false, null);
+		verify(tracker).removeAndSetSlotIndexes(eq(handler), eq(2), argThat(stack -> stack.is(Items.IRON_NUGGET) && stack.getCount() == 90));
+		verify(handler, atLeastOnce()).triggerOnChangeListeners(2);
+		clearInvocations(tracker);
+		assertEquals(90, part.extractItemIgnoringLimit(2, 100, false).getCount());
+		verify(tracker).removeAndSetSlotIndexes(eq(handler), eq(0), argThat(ItemStack::isEmpty));
+		verify(tracker).removeAndSetSlotIndexes(eq(handler), eq(1), argThat(ItemStack::isEmpty));
+		verify(tracker).removeAndSetSlotIndexes(eq(handler), eq(2), argThat(ItemStack::isEmpty));
 	}
 
 	@ParameterizedTest
@@ -554,6 +663,29 @@ public class CompressionInventoryPartTest {
 	}
 
 	@Test
+	void clearingAllMemorySlotsAllowsDifferentItemsAfterExtraction() {
+		InventoryHandler invHandler = getFilledInventoryHandler(Map.of(0, new ItemStack(Items.IRON_BLOCK, 32), 1, ItemStack.EMPTY, 2, ItemStack.EMPTY), 64);
+		when(invHandler.getSlots()).thenReturn(3);
+		MemorySettingsCategory memorySettings = new MemorySettingsCategory(() -> invHandler, new CompoundTag(), compoundTag -> {});
+		CompressionInventoryPart part = initCompressionInventoryPart(invHandler, new InventoryPartitioner.SlotRange(0, 3), () -> memorySettings);
+		when(invHandler.getStackInSlot(anyInt())).thenAnswer(i -> part.getStackInSlot(i.getArgument(0), slot -> ItemStack.EMPTY));
+		doAnswer(i -> {
+			part.onSlotFilterChanged(i.getArgument(0));
+			return null;
+		}).when(invHandler).onSlotFilterChanged(anyInt());
+		memorySettings.selectSlot(0);
+		part.extractItem(0, 32, false);
+
+		ItemStack gold = new ItemStack(Items.GOLD_BLOCK, 32);
+		assertSame(gold, part.insertItem(0, gold, false, (s, st, sim) -> ItemStack.EMPTY));
+
+		memorySettings.unselectAllSlots();
+
+		assertEquals(ItemStack.EMPTY, part.insertItem(0, gold, false, (s, st, sim) -> ItemStack.EMPTY));
+		assertStackEquals(new ItemStack(Items.GOLD_BLOCK, 32), part.getStackInSlot(0, slot -> ItemStack.EMPTY), "Inserted gold count does not equal");
+	}
+
+	@Test
 	void properlyInitializesItemsBasedOnMemorizedSlots() {
 		InventoryHandler invHandler = getFilledInventoryHandler(Map.of(0, ItemStack.EMPTY, 1, ItemStack.EMPTY, 2, ItemStack.EMPTY), 64);
 		MemorySettingsCategory memorySettings = getMemorySettings(invHandler, Map.of());
@@ -776,7 +908,7 @@ public class CompressionInventoryPartTest {
 						Map.of(0, new ItemStack(Items.IRON_BLOCK, 256), 1, new ItemStack(Items.IRON_INGOT, 256)),
 						256,
 						ImmutablePair.of(1, 256),
-						Map.of(0, new ItemStack(Items.IRON_BLOCK, 256), 1, new ItemStack(Items.IRON_INGOT, 2496))
+						Map.of(0, new ItemStack(Items.IRON_BLOCK, 256), 1, new ItemStack(Items.IRON_INGOT, 2304))
 				),
 				new ExtractingFromFullyFilledSlotsProperlyCalculatesCountsParams(
 						Map.of(0, new ItemStack(Items.IRON_BLOCK, 256), 1, new ItemStack(Items.IRON_INGOT, 256)),
@@ -794,7 +926,7 @@ public class CompressionInventoryPartTest {
 						Map.of(0, new ItemStack(Items.IRON_BLOCK, 256), 1, new ItemStack(Items.IRON_INGOT, 256), 2, new ItemStack(Items.IRON_NUGGET, 256)),
 						256,
 						ImmutablePair.of(2, 256 + 10 * 9),
-						Map.of(0, new ItemStack(Items.IRON_BLOCK, 256), 1, new ItemStack(Items.IRON_INGOT, 2560), 2, new ItemStack(Items.IRON_NUGGET, 23232)) // the extract gets maxed to 64
+						Map.of(0, new ItemStack(Items.IRON_BLOCK, 256), 1, new ItemStack(Items.IRON_INGOT, 2550), 2, new ItemStack(Items.IRON_NUGGET, 22950))
 				)
 		);
 	}
@@ -828,6 +960,95 @@ public class CompressionInventoryPartTest {
 						Map.of(0, new ItemStack(Items.IRON_INGOT, 4), 1, new ItemStack(Items.IRON_NUGGET, 3), 2, ItemStack.EMPTY, 3, new ItemStack(Items.IRON_AXE)),
 						256,
 						Map.of(0, new ItemStack(Items.IRON_INGOT, 4), 1, new ItemStack(Items.IRON_NUGGET, 3), 2, ItemStack.EMPTY, 3, new ItemStack(Items.IRON_AXE))
+				)
+		);
+	}
+
+	@ParameterizedTest
+	@MethodSource("updatingStackDirectlyAndCallingContentsChangedUpdatesCalculatedStacksProperly")
+	void updatingStackDirectlyAndCallingContentsChangedUpdatesCalculatedStacksProperly(UpdatingStackDirectlyAndCallingContentsChangedUpdatesCalculatedStacksProperlyParams params) {
+		InventoryHandler invHandler = getFilledInventoryHandler(params.stacks(), params.baseLimit());
+		int minSlot = 0;
+
+		CompressionInventoryPart part = initCompressionInventoryPart(invHandler, new InventoryPartitioner.SlotRange(minSlot, minSlot + params.stacks().size()), () -> getMemorySettings(invHandler, Map.of()));
+
+		part.getStackInSlot(params.shrunkBy.getLeft(), invHandler::getStackInSlot).shrink(params.shrunkBy.getRight());
+		part.onContentsChanged(params.shrunkBy.getLeft(), invHandler::setStackInSlot);
+
+		assertCalculatedStacks(params.expectedCalculatedStacks(), minSlot, part);
+	}
+
+	private record UpdatingStackDirectlyAndCallingContentsChangedUpdatesCalculatedStacksProperlyParams(
+			Map<Integer, ItemStack> stacks,
+			int baseLimit,
+			Pair<Integer, Integer> shrunkBy,
+			Map<Integer, ItemStack> expectedCalculatedStacks) {
+	}
+
+	private static List<UpdatingStackDirectlyAndCallingContentsChangedUpdatesCalculatedStacksProperlyParams> updatingStackDirectlyAndCallingContentsChangedUpdatesCalculatedStacksProperly() {
+		return List.of(
+				new UpdatingStackDirectlyAndCallingContentsChangedUpdatesCalculatedStacksProperlyParams(
+						Map.of(0, new ItemStack(Items.IRON_BLOCK, 1), 1, new ItemStack(Items.IRON_INGOT, 2), 2, new ItemStack(Items.IRON_NUGGET, 1)),
+						64,
+						ImmutablePair.of(2, 20),
+						Map.of(0, new ItemStack(Items.IRON_BLOCK, 0), 1, new ItemStack(Items.IRON_INGOT, 8), 2, new ItemStack(Items.IRON_NUGGET, 80))
+				)
+		);
+	}
+
+	@ParameterizedTest
+	@MethodSource("settingStackMultipleTimesResultsInCorrectCalculatedStacks")
+	void settingStackMultipleTimesResultsInCorrectCalculatedStacks(SettingStackMultipleTimesResultsInCorrectCalculatedStacksParams params) {
+		InventoryHandler invHandler = getFilledInventoryHandler(params.stacks(), params.baseLimit());
+		int minSlot = 0;
+
+		CompressionInventoryPart part = initCompressionInventoryPart(invHandler, new InventoryPartitioner.SlotRange(minSlot, minSlot + params.stacks().size()), () -> getMemorySettings(invHandler, Map.of()));
+
+		for (ItemStack stack : params.stacksToSet) {
+			part.setStackInSlot(params.slot, stack, (slot, stack1) -> {
+				invHandler.setStackInSlot(slot, stack1);
+				part.onContentsChanged(slot, invHandler::setStackInSlot); //simulates what real implementation of InventoryHandler does when slot changes (the mock used here doesn't trigger the onchange)
+			});
+		}
+
+		assertCalculatedStacks(params.expectedCalculatedStacks, minSlot, part);
+	}
+
+	private record SettingStackMultipleTimesResultsInCorrectCalculatedStacksParams(
+			Map<Integer, ItemStack> stacks,
+			int baseLimit,
+			Map<Integer, ItemStack> expectedCalculatedStacks, int slot, ItemStack... stacksToSet) {
+	}
+
+	private static List<SettingStackMultipleTimesResultsInCorrectCalculatedStacksParams> settingStackMultipleTimesResultsInCorrectCalculatedStacks() {
+		return List.of(
+				new SettingStackMultipleTimesResultsInCorrectCalculatedStacksParams(
+						Map.of(0, ItemStack.EMPTY, 1, ItemStack.EMPTY, 2, ItemStack.EMPTY),
+						64,
+						Map.of(0, new ItemStack(Items.IRON_BLOCK, 1), 1, new ItemStack(Items.IRON_INGOT, 11), 2, new ItemStack(Items.IRON_NUGGET, 100)),
+						2,
+						new ItemStack(Items.IRON_NUGGET, 100)
+				),
+				new SettingStackMultipleTimesResultsInCorrectCalculatedStacksParams(
+						Map.of(0, ItemStack.EMPTY, 1, ItemStack.EMPTY, 2, ItemStack.EMPTY),
+						64,
+						Map.of(0, new ItemStack(Items.IRON_BLOCK, 2), 1, new ItemStack(Items.IRON_INGOT, 22), 2, new ItemStack(Items.IRON_NUGGET, 200)),
+						2,
+						new ItemStack(Items.IRON_NUGGET, 100), new ItemStack(Items.IRON_NUGGET, 200)
+				),
+				new SettingStackMultipleTimesResultsInCorrectCalculatedStacksParams(
+						Map.of(0, ItemStack.EMPTY, 1, new ItemStack(Items.IRON_INGOT, 2), 2, ItemStack.EMPTY),
+						64,
+						Map.of(0, new ItemStack(Items.IRON_BLOCK, 2), 1, new ItemStack(Items.IRON_INGOT, 18), 2, new ItemStack(Items.IRON_NUGGET, 162)),
+						1,
+						new ItemStack(Items.IRON_INGOT, 2), new ItemStack(Items.IRON_INGOT, 18)
+				),
+				new SettingStackMultipleTimesResultsInCorrectCalculatedStacksParams(
+						Map.of(0, ItemStack.EMPTY, 1, new ItemStack(Items.IRON_INGOT, 2), 2, ItemStack.EMPTY),
+						64,
+						Map.of(0, new ItemStack(Items.IRON_BLOCK, 2), 1, new ItemStack(Items.IRON_INGOT, 18), 2, new ItemStack(Items.IRON_NUGGET, 162)),
+						1,
+						new ItemStack(Items.IRON_INGOT, 2), new ItemStack(Items.IRON_INGOT, 18), new ItemStack(Items.IRON_INGOT, 36), new ItemStack(Items.IRON_INGOT, 54), new ItemStack(Items.IRON_INGOT, 18)
 				)
 		);
 	}


### PR DESCRIPTION
This fixes compression-related duplication and item loss on 1.18.2, restores packed barrel tooltip contents, and corrects several barrel display models.

We still use 1.18.2 and have tested these changes in our pack. I'm sharing them in case they are useful, with no expectation of another release for this version.

Requires the companion SophisticatedCore PR: [**[1.18.x] Fix inventory transfers, shared crafting and packed storage previews**](https://github.com/P3pp3rF1y/SophisticatedCore/pull/503). Storage uses its new inventory and tooltip hooks. If these are released, the minimum Core dependency needs to be raised to the version containing those changes.

### Backported fixes

- **Refined Storage crafting duplication:** backport [82377604](https://github.com/P3pp3rF1y/SophisticatedStorage/commit/82377604ca99e79462adf8a8c156b2776d04d95a). Compression extraction returns the requested available quantity rather than stopping at the item's normal stack size. As in the upstream workaround, this deliberately allows compressed-slot extraction to exceed that size; it remains bounded by the request and available contents.
- **Direct hotbar interaction:** retain the last calculated counts and reconcile changes to displayed compression stacks against those counts. Reset remembered counts when definitions change and guard against nested reconciliation. Adapted from [e3a7d072](https://github.com/P3pp3rF1y/SophisticatedStorage/commit/e3a7d072aee223ae0f96ed0dee9add728f59652c), together with the Core hotbar fix.
- **Sorting outside slots:** handle the sort action when the cursor is outside any slot, preventing another sorting mod from applying generic sorting to oversized storage stacks. Adapted from [50457681](https://github.com/P3pp3rF1y/SophisticatedStorage/commit/50457681cec820c9929c73b2539c49776a17f517).

### Compression and interaction fixes

- Calculate each compression slot's limit from its own denomination, including chains that mix 2×2 and 3×3 recipes.
- Reject inaccessible or invalid slot definitions and incomplete insertion calculations before applying inventory changes.
- Refresh slot tracking and change listeners for all calculated slots after insertion and extraction.
- Mark compression-managed slots as unavailable to the compacting upgrade, avoiding a second conversion of their virtual contents.
- Allow an empty-main-hand sneak interaction on a limited barrel's front face to open it, and return the appropriate sided interaction result.

### Packed barrel tooltips

- Build a separate preview from the packed contents, including the stored upgrades and compression inventory definitions.
- Show each nonempty limited-barrel denomination in slot order. Two-, three- and four-slot barrels no longer appear empty when compression is installed.
- Show installed upgrade icons, the storage multiplier and barrel tier while packed. An unused slot does not produce a phantom contents entry.

### Barrel rendering

- Rotate spore blossoms outward by 90 degrees and place their attachment against the barrel face.
- Move big dripleaf forward by 6/16 and small dripleaf by 4/16, multiplied by the display scale. This keeps the stems against the face across one-, two-, three- and four-slot limited barrels.
- Add an optional Compressium display model using its block texture and tier overlay. It only applies when Compressium is loaded; unrelated items and missing expected textures keep their original models. No dependency on Compressium classes is added.
- Apply the model and position corrections to both baked and dynamic barrel displays.
- Cache count-label formatting and width in a bounded cache, clearing it on resource reload or font replacement. Reduce temporary objects when drawing fill bars while preserving their texture coordinates, lighting and placement. These are allocation reductions; no FPS improvement is claimed.

### Validation

Storage builds successfully and all 181 tests pass; the companion Core build has 69 passing tests.

In-game checks covered the Refined Storage duplication before and after the fix, AE2 normal and bulk crafting with a full inventory, repeated hotbar transfers, hopper insertion, memory unlocking, shared multiplayer crafting and sorting outside slots.

Packed tooltips were checked on limited barrels I–IV, including four Compressium denominations, multiple upgrades and a Gold-tier barrel. Spore blossom and both dripleaf models were checked from the front and at an angle. Count labels, fill bars and resource reloads were checked, along with Compressium being present and absent. JEI-returned contents also survived saving and reopening the world.

Versions are unchanged.
